### PR TITLE
chore: create client directly and bump to v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can use the library as follow:
 
 ```toml
 [dependencies]
-bigtable_rs = "0.2.0"
+bigtable_rs = "0.2.1"
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 env_logger = "0.9.1"
 ```

--- a/bigtable_rs/Cargo.toml
+++ b/bigtable_rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bigtable_rs"
 description = "A very simple Google Bigtable client lib in Rust"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fuyang Liu <liufuyang@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Let the `BigTableConnection` holds a `BigtableClient<AuthSvc>` after creation. This should allow the user to call `connection.client()` multiple times efficiently and it is equivalent as calling `client.clone()`;

Reason to change it that users seems calling `connection.client()` very often, see [an example here](https://github.com/datafusion-contrib/datafusion-bigtable/blob/f09981080ce598b4b3a20ad68ab537c895a684af/src/execute_plan.rs#L168)