### PR TITLE
Add a new optional parameter in BigTableConnection constructor for reading Service Worker JSON.

### DIFF
--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -253,7 +253,24 @@ impl BigTableConnection {
             }
         }
     }
-
+    /// Establish a connection to the BigTable instance named `instance_name`.  If read-only access
+    /// is required, the `read_only` flag should be used to reduce the requested OAuth2 scope.
+    ///
+    /// The `authentication_manager` variable will be used to determine the
+    /// program name that contains the BigTable instance in addition to access credentials.
+    ///
+    ///
+    /// `channel_size` defines the number of connections (or channels) established to Bigtable
+    /// service, and the requests are load balanced onto all the channels. You must therefore
+    /// make sure all of these connections are open when a new request is to be sent.
+    /// Idle connections are automatically closed in "a few minutes". Therefore it is important to
+    /// make sure you have a high enough QPS to send at least one request through all the
+    /// connections (in every service host) every minute. If not, you should consider decreasing the
+    /// channel size. If you are not sure what value to pick and your load is low, just start with 1.
+    /// The recommended value could be 2 x the thread count in your tokio environment see info here
+    /// https://docs.rs/tokio/latest/tokio/attr.main.html, but it might be a very different case for
+    /// different applications.
+    ///
     pub async fn new_with_auth_manager(
         project_id: &str,
         instance_name: &str,

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -90,7 +90,7 @@ use core::time;
 use std::sync::Arc;
 use std::time::Duration;
 
-use gcp_auth::{AuthenticationManager, CustomServiceAccount};
+use gcp_auth::AuthenticationManager;
 use log::info;
 use thiserror::Error;
 use tonic::transport::Endpoint;

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -86,7 +86,6 @@
 //! }
 //! ```
 
-use core::time;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -247,7 +247,6 @@ impl BigTableConnection {
             }
 
             Err(_) => {
-
                 let authentication_manager = AuthenticationManager::new().await?;
 
                 let table_prefix = format!(

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -305,85 +305,51 @@ impl BigTableConnection {
         timeout: Option<Duration>,
         credential_path: &str,
     ) -> Result<Self> {
-        match std::env::var("BIGTABLE_EMULATOR_HOST") {
-            Ok(endpoint) => {
-                info!("Connecting to bigtable emulator at {}", endpoint);
-                let endpoints: Vec<Endpoint> = vec![0; channel_size.max(1)]
-                    .iter()
-                    .map(move |_| {
-                        Channel::from_shared(format!("http://{}", endpoint))
-                            .expect("Invalid connection emulator uri")
-                            .http2_keep_alive_interval(Duration::from_secs(60))
-                            .keep_alive_while_idle(true)
-                    })
-                    .map(|ep| {
-                        if let Some(timeout) = timeout {
-                            ep.timeout(timeout)
-                        } else {
-                            ep
-                        }
-                    })
-                    .collect();
+        let authentication_manager = AuthenticationManager::from(CustomServiceAccount::from_file(credential_path)?);
+        
+        let table_prefix = format!(
+            "projects/{}/instances/{}/tables/",
+            project_id, instance_name
+        );
 
-                Ok(Self {
-                    client: create_client(endpoints, None, is_read_only),
-                    table_prefix: Arc::new(format!(
-                        "projects/{}/instances/{}/tables/",
-                        project_id, instance_name
-                    )),
-                    timeout: Arc::new(timeout),
-                })
-            }
-
-            Err(_) => {
-
-                let authentication_manager = AuthenticationManager::from(CustomServiceAccount::from_file(credential_path)?);
-                
-                let table_prefix = format!(
-                    "projects/{}/instances/{}/tables/",
-                    project_id, instance_name
-                );
-
-                let endpoints: Result<Vec<Endpoint>> = vec![0; channel_size.max(1)]
-                    .iter()
-                    .map(move |_| {
-                        Channel::from_static("https://bigtable.googleapis.com")
-                            .tls_config(
-                                ClientTlsConfig::new()
-                                    .ca_certificate(
-                                        root_ca_certificate::load()
-                                            .map_err(Error::CertificateError)
-                                            .expect("root certificate error"),
-                                    )
-                                    .domain_name("bigtable.googleapis.com"),
+        let endpoints: Result<Vec<Endpoint>> = vec![0; channel_size.max(1)]
+            .iter()
+            .map(move |_| {
+                Channel::from_static("https://bigtable.googleapis.com")
+                    .tls_config(
+                        ClientTlsConfig::new()
+                            .ca_certificate(
+                                root_ca_certificate::load()
+                                    .map_err(Error::CertificateError)
+                                    .expect("root certificate error"),
                             )
-                            .map_err(Error::TransportError)
-                    })
-                    .collect();
+                            .domain_name("bigtable.googleapis.com"),
+                    )
+                    .map_err(Error::TransportError)
+            })
+            .collect();
 
-                let endpoints: Vec<Endpoint> = endpoints?
-                    .into_iter()
-                    .map(|ep| {
-                        ep.http2_keep_alive_interval(Duration::from_secs(60))
-                            .keep_alive_while_idle(true)
-                    })
-                    .map(|ep| {
-                        if let Some(timeout) = timeout {
-                            ep.timeout(timeout)
-                        } else {
-                            ep
-                        }
-                    })
-                    .collect();
+        let endpoints: Vec<Endpoint> = endpoints?
+            .into_iter()
+            .map(|ep| {
+                ep.http2_keep_alive_interval(Duration::from_secs(60))
+                    .keep_alive_while_idle(true)
+            })
+            .map(|ep| {
+                if let Some(timeout) = timeout {
+                    ep.timeout(timeout)
+                } else {
+                    ep
+                }
+            })
+            .collect();
 
-                let auth_manager = Some(Arc::new(authentication_manager));
-                Ok(Self {
-                    client: create_client(endpoints, auth_manager, is_read_only),
-                    table_prefix: Arc::new(table_prefix),
-                    timeout: Arc::new(timeout),
-                })
-            }
-        }
+        let auth_manager = Some(Arc::new(authentication_manager));
+        Ok(Self {
+            client: create_client(endpoints, auth_manager, is_read_only),
+            table_prefix: Arc::new(table_prefix),
+            timeout: Arc::new(timeout),
+        })
     }
 
     /// Create a new BigTable client by cloning needed properties.

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -217,6 +217,35 @@ impl BigTableConnection {
         channel_size: usize,
         timeout: Option<Duration>,
     ) -> Result<Self> {
+        let authentication_manager = AuthenticationManager::new().await?;
+        Self::new_with_auth_manager(project_id, instance_name, is_read_only, channel_size, timeout, authentication_manager).await
+    }
+    /// Establish a connection to the BigTable instance named `instance_name`.  If read-only access
+    /// is required, the `read_only` flag should be used to reduce the requested OAuth2 scope.
+    ///
+    /// The `authentication_manager` variable will be used to determine the
+    /// program name that contains the BigTable instance in addition to access credentials.
+    ///
+    ///
+    /// `channel_size` defines the number of connections (or channels) established to Bigtable
+    /// service, and the requests are load balanced onto all the channels. You must therefore
+    /// make sure all of these connections are open when a new request is to be sent.
+    /// Idle connections are automatically closed in "a few minutes". Therefore it is important to
+    /// make sure you have a high enough QPS to send at least one request through all the
+    /// connections (in every service host) every minute. If not, you should consider decreasing the
+    /// channel size. If you are not sure what value to pick and your load is low, just start with 1.
+    /// The recommended value could be 2 x the thread count in your tokio environment see info here
+    /// https://docs.rs/tokio/latest/tokio/attr.main.html, but it might be a very different case for
+    /// different applications.
+    ///
+    pub async fn new_with_auth_manager(
+        project_id: &str,
+        instance_name: &str,
+        is_read_only: bool,
+        channel_size: usize,
+        timeout: Option<Duration>,
+        authentication_manager: AuthenticationManager,
+    ) -> Result<Self> {      
         match std::env::var("BIGTABLE_EMULATOR_HOST") {
             Ok(endpoint) => {
                 info!("Connecting to bigtable emulator at {}", endpoint);
@@ -248,80 +277,51 @@ impl BigTableConnection {
             }
 
             Err(_) => {
-                let authentication_manager = AuthenticationManager::new().await?;
-                Self::new_with_auth_manager(project_id, instance_name, is_read_only, channel_size, timeout, authentication_manager).await
-            }
-        }
-    }
-    /// Establish a connection to the BigTable instance named `instance_name`.  If read-only access
-    /// is required, the `read_only` flag should be used to reduce the requested OAuth2 scope.
-    ///
-    /// The `authentication_manager` variable will be used to determine the
-    /// program name that contains the BigTable instance in addition to access credentials.
-    ///
-    ///
-    /// `channel_size` defines the number of connections (or channels) established to Bigtable
-    /// service, and the requests are load balanced onto all the channels. You must therefore
-    /// make sure all of these connections are open when a new request is to be sent.
-    /// Idle connections are automatically closed in "a few minutes". Therefore it is important to
-    /// make sure you have a high enough QPS to send at least one request through all the
-    /// connections (in every service host) every minute. If not, you should consider decreasing the
-    /// channel size. If you are not sure what value to pick and your load is low, just start with 1.
-    /// The recommended value could be 2 x the thread count in your tokio environment see info here
-    /// https://docs.rs/tokio/latest/tokio/attr.main.html, but it might be a very different case for
-    /// different applications.
-    ///
-    pub async fn new_with_auth_manager(
-        project_id: &str,
-        instance_name: &str,
-        is_read_only: bool,
-        channel_size: usize,
-        timeout: Option<Duration>,
-        authentication_manager: AuthenticationManager,
-    ) -> Result<Self> {        
-        let table_prefix = format!(
-            "projects/{}/instances/{}/tables/",
-            project_id, instance_name
-        );
-
-        let endpoints: Result<Vec<Endpoint>> = vec![0; channel_size.max(1)]
-            .iter()
-            .map(move |_| {
-                Channel::from_static("https://bigtable.googleapis.com")
-                    .tls_config(
-                        ClientTlsConfig::new()
-                            .ca_certificate(
-                                root_ca_certificate::load()
-                                    .map_err(Error::CertificateError)
-                                    .expect("root certificate error"),
+                let table_prefix = format!(
+                    "projects/{}/instances/{}/tables/",
+                    project_id, instance_name
+                );
+        
+                let endpoints: Result<Vec<Endpoint>> = vec![0; channel_size.max(1)]
+                    .iter()
+                    .map(move |_| {
+                        Channel::from_static("https://bigtable.googleapis.com")
+                            .tls_config(
+                                ClientTlsConfig::new()
+                                    .ca_certificate(
+                                        root_ca_certificate::load()
+                                            .map_err(Error::CertificateError)
+                                            .expect("root certificate error"),
+                                    )
+                                    .domain_name("bigtable.googleapis.com"),
                             )
-                            .domain_name("bigtable.googleapis.com"),
-                    )
-                    .map_err(Error::TransportError)
-            })
-            .collect();
-
-        let endpoints: Vec<Endpoint> = endpoints?
-            .into_iter()
-            .map(|ep| {
-                ep.http2_keep_alive_interval(Duration::from_secs(60))
-                    .keep_alive_while_idle(true)
-            })
-            .map(|ep| {
-                if let Some(timeout) = timeout {
-                    ep.timeout(timeout)
-                } else {
-                    ep
-                }
-            })
-            .collect();
-
-        let auth_manager = Some(Arc::new(authentication_manager));
-        Ok(Self {
-            client: create_client(endpoints, auth_manager, is_read_only),
-            table_prefix: Arc::new(table_prefix),
-            timeout: Arc::new(timeout),
-        })
+                            .map_err(Error::TransportError)
+                    })
+                    .collect();
+        
+                let endpoints: Vec<Endpoint> = endpoints?
+                    .into_iter()
+                    .map(|ep| {
+                        ep.http2_keep_alive_interval(Duration::from_secs(60))
+                            .keep_alive_while_idle(true)
+                    })
+                    .map(|ep| {
+                        if let Some(timeout) = timeout {
+                            ep.timeout(timeout)
+                        } else {
+                            ep
+                        }
+                    })
+                    .collect();
+        
+                let auth_manager = Some(Arc::new(authentication_manager));
+                Ok(Self {
+                    client: create_client(endpoints, auth_manager, is_read_only),
+                    table_prefix: Arc::new(table_prefix),
+                    timeout: Arc::new(timeout),
+                })
+            }
+        }  
     }
 
     /// Create a new BigTable client by cloning needed properties.

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -217,7 +217,15 @@ impl BigTableConnection {
         timeout: Option<Duration>,
     ) -> Result<Self> {
         let authentication_manager = AuthenticationManager::new().await?;
-        Self::new_with_auth_manager(project_id, instance_name, is_read_only, channel_size, timeout, authentication_manager).await
+        Self::new_with_auth_manager(
+            project_id,
+            instance_name,
+            is_read_only,
+            channel_size,
+            timeout,
+            authentication_manager,
+        )
+        .await
     }
     /// Establish a connection to the BigTable instance named `instance_name`.  If read-only access
     /// is required, the `read_only` flag should be used to reduce the requested OAuth2 scope.
@@ -244,7 +252,7 @@ impl BigTableConnection {
         channel_size: usize,
         timeout: Option<Duration>,
         authentication_manager: AuthenticationManager,
-    ) -> Result<Self> {      
+    ) -> Result<Self> {
         match std::env::var("BIGTABLE_EMULATOR_HOST") {
             Ok(endpoint) => {
                 info!("Connecting to bigtable emulator at {}", endpoint);
@@ -280,7 +288,7 @@ impl BigTableConnection {
                     "projects/{}/instances/{}/tables/",
                     project_id, instance_name
                 );
-        
+
                 let endpoints: Result<Vec<Endpoint>> = vec![0; channel_size.max(1)]
                     .iter()
                     .map(move |_| {
@@ -297,7 +305,7 @@ impl BigTableConnection {
                             .map_err(Error::TransportError)
                     })
                     .collect();
-        
+
                 let endpoints: Vec<Endpoint> = endpoints?
                     .into_iter()
                     .map(|ep| {
@@ -312,7 +320,7 @@ impl BigTableConnection {
                         }
                     })
                     .collect();
-        
+
                 let auth_manager = Some(Arc::new(authentication_manager));
                 Ok(Self {
                     client: create_client(endpoints, auth_manager, is_read_only),
@@ -320,7 +328,7 @@ impl BigTableConnection {
                     timeout: Arc::new(timeout),
                 })
             }
-        }  
+        }
     }
 
     /// Create a new BigTable client by cloning needed properties.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,6 +22,10 @@ name = "http_server"
 path = "src/http_server/http_server.rs"
 
 [[bin]]
+name = "custom_path_connection"
+path = "src/custom_path_connection.rs"
+
+[[bin]]
 name = "prefix"
 path = "src/prefix.rs"
 
@@ -33,3 +37,4 @@ log = "0.4.20"
 warp = "0.3.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+gcp_auth = "0.9.0"

--- a/examples/src/custom_path_connection.rs
+++ b/examples/src/custom_path_connection.rs
@@ -1,0 +1,88 @@
+use bigtable_rs::bigtable;
+use bigtable_rs::google::bigtable::v2::mutation;
+use bigtable_rs::google::bigtable::v2::mutation::SetCell;
+use bigtable_rs::google::bigtable::v2::row_filter::Filter;
+use bigtable_rs::google::bigtable::v2::{
+    MutateRowRequest, Mutation, ReadRowsRequest, RowFilter, RowSet,
+};
+use env_logger;
+use gcp_auth::{AuthenticationManager, CustomServiceAccount};
+use std::error::Error;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    let project_id = "project-1";
+    let instance_name = "instance-1";
+    let table_name = "table-1";
+    let channel_size = 4;
+    let timeout = Duration::from_secs(10);
+
+    let key: String = "key3".to_owned();
+
+    let json_path:&str = "path/to/json";
+    // make a bigtable client
+    let connection = bigtable::BigTableConnection::new_with_auth_manager(
+        project_id,
+        instance_name,
+        false,
+        channel_size,
+        Some(timeout),
+        AuthenticationManager::from(CustomServiceAccount::from_file(json_path).unwrap())
+    )
+    .await?;
+    let mut bigtable = connection.client();
+
+    let request = MutateRowRequest {
+        table_name: bigtable.get_full_table_name(table_name),
+        row_key: key.clone().into_bytes(),
+        mutations: vec![Mutation {
+            mutation: Some(mutation::Mutation::SetCell(SetCell {
+                family_name: "cf1".to_owned(),
+                column_qualifier: "c1".to_owned().into_bytes(),
+                timestamp_micros: -1, // IMPORTANT: Don't leave it empty. Use -1 for current Bigtable server time.
+                value: "a new write value".to_owned().into_bytes(),
+            })),
+        }],
+        ..MutateRowRequest::default()
+    };
+
+    // write to table
+    let _response = bigtable.mutate_row(request).await?;
+
+    // read from table again
+    // prepare a ReadRowsRequest
+    let request = ReadRowsRequest {
+        table_name: bigtable.get_full_table_name(table_name),
+        rows_limit: 10,
+        rows: Some(RowSet {
+            row_keys: vec![key.clone().into_bytes()],
+            row_ranges: vec![],
+        }),
+        filter: Some(RowFilter {
+            filter: Some(Filter::CellsPerColumnLimitFilter(1)),
+        }),
+        ..ReadRowsRequest::default()
+    };
+
+    // calling bigtable API to get results
+    let response = bigtable.read_rows(request).await?;
+
+    // simply print results for example usage
+    response.into_iter().for_each(|(key, data)| {
+        println!("------------\n{}", String::from_utf8(key.clone()).unwrap());
+        data.into_iter().for_each(|row_cell| {
+            println!(
+                "    [{}:{}] \"{}\" @ {}",
+                row_cell.family_name,
+                String::from_utf8(row_cell.qualifier).unwrap(),
+                String::from_utf8(row_cell.value).unwrap(),
+                row_cell.timestamp_micros
+            )
+        })
+    });
+
+    Ok(())
+}

--- a/examples/src/custom_path_connection.rs
+++ b/examples/src/custom_path_connection.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let key: String = "key3".to_owned();
 
-    let json_path:&str = "path/to/json";
+    let json_path: &str = "path/to/json";
     // make a bigtable client
     let connection = bigtable::BigTableConnection::new_with_auth_manager(
         project_id,
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         false,
         channel_size,
         Some(timeout),
-        AuthenticationManager::from(CustomServiceAccount::from_file(json_path).unwrap())
+        AuthenticationManager::from(CustomServiceAccount::from_file(json_path).unwrap()),
     )
     .await?;
     let mut bigtable = connection.client();


### PR DESCRIPTION
This pull request introduces a new optional parameter to the BigTableConnection class, aimed at enhancing its flexibility and ease of use by allowing the option to read configuration from a Service Worker JSON file. This addition caters to the growing need for applications to dynamically configure their BigTable connections, especially in environments where configuration management is centralised or where multiple environments require different settings.