### PR TITLE
make `google::rpc` module public

### DIFF
--- a/bigtable_rs/src/google.rs
+++ b/bigtable_rs/src/google.rs
@@ -18,4 +18,4 @@ pub mod cloud {
 }
 
 #[path = "google/google.rpc.rs"]
-mod rpc;
+pub mod rpc;


### PR DESCRIPTION
Is there a reason for the `google::rpc` module to be private? This prevents pattern matching or mocking `rpc::Status` in tests. 