### PR TITLE
chore: bump gcp_auth to 0.12.2

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           submodules: 'true'
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check fmt

--- a/bigtable_rs/Cargo.toml
+++ b/bigtable_rs/Cargo.toml
@@ -24,7 +24,7 @@ prost-wkt-types = "0.5.0"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_with = { version = "3.4.0", features = ["base64"] }
 # end of above part
-gcp_auth = "0.10.0"
+gcp_auth = "0.12.2"
 log = "0.4.20"
 thiserror = "1.0.50"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,4 +37,4 @@ log = "0.4.20"
 warp = "0.3.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-gcp_auth = "0.10.0"
+gcp_auth = "0.12.0"

--- a/examples/src/custom_path_connection.rs
+++ b/examples/src/custom_path_connection.rs
@@ -6,8 +6,9 @@ use bigtable_rs::google::bigtable::v2::{
     MutateRowRequest, Mutation, ReadRowsRequest, RowFilter, RowSet,
 };
 use env_logger;
-use gcp_auth::{AuthenticationManager, CustomServiceAccount};
+use gcp_auth::CustomServiceAccount;
 use std::error::Error;
+use std::sync::Arc;
 use std::time::Duration;
 
 #[tokio::main]
@@ -24,13 +25,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let json_path: &str = "examples/src/custom_path_fake_key.json";
     // make a bigtable client
-    let connection = bigtable::BigTableConnection::new_with_auth_manager(
+    let connection = bigtable::BigTableConnection::new_with_token_provider(
         project_id,
         instance_name,
         false,
         channel_size,
         Some(timeout),
-        AuthenticationManager::from(CustomServiceAccount::from_file(json_path).unwrap()),
+        Arc::new(CustomServiceAccount::from_file(json_path).unwrap()),
     )?;
     let mut bigtable = connection.client();
 


### PR DESCRIPTION
gcp_auth changed their AuthenticationManager API in https://github.com/djc/gcp_auth/pull/108.
    
gcp_auth::provider() now returns a Arc<dyn TokenProvider>,
rather than a AuthenticationManager, and AuthenticationManager is gone.
    
This updates references in bigtable_rs codebase to follow.
    
Closes #75.