### PR TITLE
Add streaming support for reading rows from Bigtable

### DIFF
--- a/bigtable_rs/Cargo.toml
+++ b/bigtable_rs/Cargo.toml
@@ -25,6 +25,7 @@ prost-wkt-types = { version = "0.6.0" }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_with = { version = "3.4.0", features = ["base64"] }
 # end of above part
+futures-util = "0.3.31"
 gcp_auth = "0.12.2"
 log = "0.4.20"
 thiserror = "1.0.50"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,10 +37,15 @@ path = "src/prefix.rs"
 name = "custom_query"
 path = "src/custom_query.rs"
 
+[[bin]]
+name = "stream"
+path = "src/stream.rs"
+
 [dependencies]
 bigtable_rs = { path = "../bigtable_rs" }
 tokio = { version = "1.34.0", features = ["rt-multi-thread"] }
 env_logger = "0.11.1"
+futures-util = "0.3.31"
 log = "0.4.20"
 warp = "0.3.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/src/stream.rs
+++ b/examples/src/stream.rs
@@ -1,0 +1,82 @@
+use bigtable_rs::bigtable;
+use bigtable_rs::google::bigtable::v2::row_filter::{Chain, Filter};
+use bigtable_rs::google::bigtable::v2::row_range::{EndKey, StartKey};
+use bigtable_rs::google::bigtable::v2::{ReadRowsRequest, RowFilter, RowRange, RowSet};
+use env_logger;
+use futures_util::TryStreamExt;
+use std::error::Error;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    let project_id = "project-1";
+    let instance_name = "instance-1";
+    let table_name = "table-1";
+    let channel_size = 4;
+    let timeout = Duration::from_secs(10);
+
+    let key_start: String = "key1".to_owned();
+    let key_end: String = "key4".to_owned();
+
+    // make a bigtable client
+    let connection = bigtable::BigTableConnection::new(
+        project_id,
+        instance_name,
+        true,
+        channel_size,
+        Some(timeout),
+    )
+    .await?;
+    let mut bigtable = connection.client();
+
+    // prepare a ReadRowsRequest
+    let request = ReadRowsRequest {
+        app_profile_id: "default".to_owned(),
+        table_name: bigtable.get_full_table_name(table_name),
+        rows_limit: 10,
+        rows: Some(RowSet {
+            row_keys: vec![], // use this field to put keys for reading specific rows
+            row_ranges: vec![RowRange {
+                start_key: Some(StartKey::StartKeyClosed(key_start.into_bytes())),
+                end_key: Some(EndKey::EndKeyOpen(key_end.into_bytes())),
+            }],
+        }),
+        filter: Some(RowFilter {
+            filter: Some(Filter::Chain(Chain {
+                filters: vec![
+                    RowFilter {
+                        filter: Some(Filter::FamilyNameRegexFilter("cf1".to_owned())),
+                    },
+                    RowFilter {
+                        filter: Some(Filter::ColumnQualifierRegexFilter("c1".as_bytes().to_vec())),
+                    },
+                    RowFilter {
+                        filter: Some(Filter::CellsPerColumnLimitFilter(2)),
+                    },
+                ],
+            })),
+        }),
+        ..ReadRowsRequest::default()
+    };
+
+    // calling bigtable API to get streaming results
+    let mut stream = bigtable.stream_rows(request).await?;
+
+    // process the stream of results
+    while let Some((key, data)) = stream.try_next().await? {
+        println!("------------\n{}", String::from_utf8(key.clone()).unwrap());
+        data.into_iter().for_each(|row_cell| {
+            println!(
+                "    [{}:{}] \"{}\" @ {}",
+                row_cell.family_name,
+                String::from_utf8(row_cell.qualifier).unwrap(),
+                String::from_utf8(row_cell.value).unwrap(),
+                row_cell.timestamp_micros
+            )
+        });
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# Add streaming support for reading rows from Bigtable

This PR adds streaming support for reading rows from Bigtable, allowing for more efficient processing of large result sets by streaming results as they arrive rather than waiting for the complete response.

## Key Changes

1. Added new streaming methods to `BigTable`:
   - `stream_rows()` - Stream results from a standard row query 
   - `stream_rows_with_prefix()` - Stream results from a prefix-based query

2. Added new dependency:
   - `futures-util = "0.3.31"` to both bigtable_rs and examples crates

3. Implemented streaming support in `read_rows.rs` with `decode_read_rows_response_stream()`

4. Added a new example demonstrating streaming usage in `examples/src/stream.rs`

## Benefits

- More memory efficient for large result sets by processing rows as they arrive
- Allows processing to begin before all results are received
- Maintains consistent timeout handling with existing non-streaming methods
- Preserves existing row parsing logic that is tested through conformance tests

## Note on Streaming and H2 Flow Control

The implementation leverages Tonic's H2 backpressure handling to create end-to-end flow control: consumers request data via `try_next()`, which pulls from Tonic only when ready, allowing the server to throttle based on client capacity. This native H2 flow control is particularly well-suited for Bigtable's variable-sized result sets and processing times, providing memory efficiency and network resilience without additional complexity.

## Example Usage

The new streaming API allows for processing results as they arrive:

```
❯ cargo run --package examples --bin stream
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/stream`
------------
key1
    [cf1:c1] "value1.v1" @ 1730754124325000
    [cf1:c1] "value1" @ 1730754120003000
------------
key2
    [cf1:c1] "value2" @ 1730754153781000
    [cf1:c1] "value2" @ 1730754120242000
------------
key3
    [cf1:c1] "value3" @ 1730754120486000
```