### PR TITLE
ref: Extract transport layer into dedicated module

### DIFF
--- a/bigtable_rs/src/auth_service.rs
+++ b/bigtable_rs/src/auth_service.rs
@@ -9,7 +9,7 @@ use log::debug;
 use tonic::body::Body;
 use tower::Service;
 
-use crate::bigtable::BoxTransport;
+use crate::transport::BoxTransport;
 
 #[derive(Clone)]
 pub struct AuthSvc {

--- a/bigtable_rs/src/auth_service.rs
+++ b/bigtable_rs/src/auth_service.rs
@@ -7,19 +7,20 @@ use gcp_auth::TokenProvider;
 use http::{HeaderValue, Request, Response};
 use log::debug;
 use tonic::body::Body;
-use tonic::transport::Channel;
 use tower::Service;
+
+use crate::bigtable::BoxTransport;
 
 #[derive(Clone)]
 pub struct AuthSvc {
-    inner: Channel,
+    inner: BoxTransport,
     token_provider: Option<Arc<dyn TokenProvider>>,
     scopes: String,
 }
 
 impl AuthSvc {
     pub fn new(
-        inner: Channel,
+        inner: BoxTransport,
         authentication_manager: Option<Arc<dyn TokenProvider>>,
         scopes: String,
     ) -> Self {
@@ -38,7 +39,7 @@ impl Service<Request<Body>> for AuthSvc {
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(Into::into)
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, mut request: Request<Body>) -> Self::Future {

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -98,7 +98,11 @@ use tokio::net::UnixStream;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Endpoint;
 use tonic::IntoRequest;
-use tonic::{codec::Streaming, transport::Channel, transport::ClientTlsConfig, Response};
+use tonic::{
+    codec::Streaming,
+    transport::{channel::Change, Channel, ClientTlsConfig},
+    Response,
+};
 use tower::ServiceBuilder;
 
 use crate::auth_service::AuthSvc;
@@ -248,24 +252,17 @@ impl BigTableConnection {
             }
         }
     }
-    /// Establish a connection to the BigTable instance named `instance_name`.  If read-only access
+    /// Establish a connection to the BigTable instance named `instance_name`. If read-only access
     /// is required, the `read_only` flag should be used to reduce the requested OAuth2 scope.
     ///
     /// The `authentication_manager` variable will be used to determine the
     /// program name that contains the BigTable instance in addition to access credentials.
     ///
-    ///
     /// `channel_size` defines the number of connections (or channels) established to Bigtable
-    /// service, and the requests are load balanced onto all the channels. You must therefore
-    /// make sure all of these connections are open when a new request is to be sent.
-    /// Idle connections are automatically closed in "a few minutes". Therefore it is important to
-    /// make sure you have a high enough QPS to send at least one request through all the
-    /// connections (in every service host) every minute. If not, you should consider decreasing the
-    /// channel size. If you are not sure what value to pick and your load is low, just start with 1.
-    /// The recommended value could be 2 x the thread count in your tokio environment see info here
-    /// https://docs.rs/tokio/latest/tokio/attr.main.html, but it might be a very different case for
-    /// different applications.
-    ///
+    /// service, and the requests are load balanced onto all the channels.
+    /// Consult the [Bigtable
+    /// docs](https://docs.cloud.google.com/bigtable/docs/configure-connection-pools) for guidance
+    /// on how to determine the optimal pool size for your application.
     pub fn new_with_token_provider(
         project_id: &str,
         instance_name: &str,
@@ -287,40 +284,31 @@ impl BigTableConnection {
                 let instance_prefix = format!("projects/{project_id}/instances/{instance_name}");
                 let table_prefix = format!("{instance_prefix}/tables/");
 
-                let endpoints: Result<Vec<Endpoint>> = vec![0; channel_size.max(1)]
-                    .iter()
-                    .map(move |_| {
-                        Channel::from_static("https://bigtable.googleapis.com")
-                            .tls_config(
-                                ClientTlsConfig::new()
-                                    .ca_certificate(
-                                        root_ca_certificate::load()
-                                            .map_err(Error::CertificateError)
-                                            .expect("root certificate error"),
-                                    )
-                                    .domain_name("bigtable.googleapis.com"),
-                            )
-                            .map_err(Error::TransportError)
-                    })
-                    .collect();
+                let (channel, tx) = Channel::balance_channel(1024);
+                for i in 0..channel_size.max(1) {
+                    let endpoint = Channel::from_static("https://bigtable.googleapis.com")
+                        .tls_config(
+                            ClientTlsConfig::new()
+                                .ca_certificate(
+                                    root_ca_certificate::load()
+                                        .map_err(Error::CertificateError)
+                                        .expect("root certificate error"),
+                                )
+                                .domain_name("bigtable.googleapis.com"),
+                        )
+                        .map_err(Error::TransportError)?
+                        .http2_keep_alive_interval(Duration::from_secs(60))
+                        .keep_alive_while_idle(true);
 
-                let endpoints: Vec<Endpoint> = endpoints?
-                    .into_iter()
-                    .map(|ep| {
-                        ep.http2_keep_alive_interval(Duration::from_secs(60))
-                            .keep_alive_while_idle(true)
-                    })
-                    .map(|ep| {
-                        if let Some(timeout) = timeout {
-                            ep.timeout(timeout)
-                        } else {
-                            ep
-                        }
-                    })
-                    .collect();
+                    let endpoint = if let Some(timeout) = timeout {
+                        endpoint.timeout(timeout)
+                    } else {
+                        endpoint
+                    };
 
-                // construct a channel, by balancing over all endpoints.
-                let channel = Channel::balance_list(endpoints.into_iter());
+                    // Use unique keys to ensure each channel has a dedicated HTTP connection
+                    tx.try_send(Change::Insert(i, endpoint)).unwrap();
+                }
 
                 let token_provider = Some(token_provider);
                 Ok(Self {

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -220,6 +220,31 @@ where
     BoxTransport::new(transport.map_err(Into::into))
 }
 
+/// A wrapper around a `Service` that holds background tasks alive via an `Arc<JoinSet>`.
+/// When the last clone is dropped, all background tasks are aborted.
+#[derive(Clone)]
+struct ManagedTransport<T> {
+    inner: T,
+    _bg_tasks: Arc<tokio::task::JoinSet<()>>,
+}
+
+impl<T, Req> Service<Req> for ManagedTransport<T>
+where
+    T: Service<Req>,
+{
+    type Response = T::Response;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
 /// For initiate a Bigtable connection, then a `Bigtable` client can be made from it.
 #[derive(Clone)]
 pub struct BigTableConnection {
@@ -227,8 +252,6 @@ pub struct BigTableConnection {
     table_prefix: Arc<String>,
     instance_prefix: Arc<String>,
     timeout: Arc<Option<Duration>>,
-    // When the last clone is dropped, aborts all background tasks (if any).
-    _bg_tasks: Option<Arc<tokio::task::JoinSet<()>>>,
 }
 
 impl BigTableConnection {
@@ -325,7 +348,6 @@ impl BigTableConnection {
                     table_prefix: Arc::new(table_prefix),
                     instance_prefix: Arc::new(instance_prefix),
                     timeout: Arc::new(timeout),
-                    _bg_tasks: None,
                 })
             }
         }
@@ -398,7 +420,6 @@ impl BigTableConnection {
                 project_id, instance_name
             )),
             timeout: Arc::new(timeout),
-            _bg_tasks: None,
         })
     }
 
@@ -447,12 +468,16 @@ impl BigTableConnection {
         manager.seed().await?;
         background_tasks.spawn(async move { manager.run().await });
 
+        let transport = ManagedTransport {
+            inner: service,
+            _bg_tasks: Arc::new(background_tasks),
+        };
+
         Ok(Self {
-            client: create_client(box_transport(service), Some(token_provider), is_read_only),
+            client: create_client(box_transport(transport), Some(token_provider), is_read_only),
             table_prefix: Arc::new(table_prefix),
             instance_prefix: Arc::new(instance_prefix),
             timeout: Arc::new(timeout),
-            _bg_tasks: Some(Arc::new(background_tasks)),
         })
     }
 }
@@ -610,8 +635,6 @@ impl ChannelManager {
     }
 }
 
-impl BigTableConnection {}
-
 // Analogous to `tonic::transport::channel::service::discover::DynamicServiceStream`, which `tonic`
 // itself doesn't expose.
 struct ChannelStream {
@@ -653,7 +676,6 @@ impl BigTableConnection {
             instance_prefix: self.instance_prefix.clone(),
             table_prefix: self.table_prefix.clone(),
             timeout: self.timeout.clone(),
-            _bg_tasks: self._bg_tasks.clone(),
         }
     }
 
@@ -708,10 +730,6 @@ pub struct BigTable {
     instance_prefix: Arc<String>,
     table_prefix: Arc<String>,
     timeout: Arc<Option<Duration>>,
-    // Arc that holds a reference to the _bg_tasks from the BigTableConnection this was created from.
-    // This is needed as we want to keep the tasks alive even if the user drops the BigTableConnection
-    // this BigTable instance originated from.
-    _bg_tasks: Option<Arc<tokio::task::JoinSet<()>>>,
 }
 
 impl BigTable {

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -92,18 +92,31 @@ use std::time::Duration;
 
 use futures_util::Stream;
 use gcp_auth::TokenProvider;
-use log::info;
+use http::{Request as HttpRequest, Response as HttpResponse};
+use log::{debug, info, warn};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 use thiserror::Error;
 use tokio::net::UnixStream;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::{channel, Sender};
+use tonic::body::Body;
 use tonic::metadata::MetadataValue;
+use tonic::transport::channel::Change;
 use tonic::transport::Endpoint;
 use tonic::IntoRequest;
 use tonic::{
     codec::Streaming,
-    transport::{channel::Change, Channel, ClientTlsConfig},
+    transport::{Channel, ClientTlsConfig},
     Response,
 };
-use tower::ServiceBuilder;
+use tower::load::{CompleteOnResponse, PendingRequests};
+use tower::util::ServiceExt;
+use tower::{balance::p2c::Balance, buffer::Buffer};
+use tower::{discover::Change as TowerChange, util::BoxCloneSyncService};
+use tower::{BoxError, Service, ServiceBuilder};
 
 use crate::auth_service::AuthSvc;
 use crate::bigtable::read_rows::{decode_read_rows_response, decode_read_rows_response_stream};
@@ -113,6 +126,7 @@ use crate::google::bigtable::v2::{
 };
 use crate::google::bigtable::v2::{
     CheckAndMutateRowRequest, CheckAndMutateRowResponse, ExecuteQueryRequest, ExecuteQueryResponse,
+    PingAndWarmRequest,
 };
 use crate::{root_ca_certificate, util::get_row_range_from_prefix};
 
@@ -194,6 +208,18 @@ impl std::convert::From<tonic::Status> for Error {
     }
 }
 
+/// The underlying `tower::Service` used to dispatch HTTP requests.
+pub(crate) type BoxTransport = BoxCloneSyncService<HttpRequest<Body>, HttpResponse<Body>, BoxError>;
+
+fn box_transport<T>(transport: T) -> BoxTransport
+where
+    T: Service<HttpRequest<Body>, Response = HttpResponse<Body>> + Clone + Send + Sync + 'static,
+    T::Error: Into<BoxError>,
+    T::Future: Send + 'static,
+{
+    BoxTransport::new(transport.map_err(Into::into))
+}
+
 /// For initiate a Bigtable connection, then a `Bigtable` client can be made from it.
 #[derive(Clone)]
 pub struct BigTableConnection {
@@ -201,6 +227,8 @@ pub struct BigTableConnection {
     table_prefix: Arc<String>,
     instance_prefix: Arc<String>,
     timeout: Arc<Option<Duration>>,
+    // When the last clone is dropped, aborts all background tasks (if any).
+    _bg_tasks: Option<Arc<tokio::task::JoinSet<()>>>,
 }
 
 impl BigTableConnection {
@@ -286,36 +314,18 @@ impl BigTableConnection {
 
                 let (channel, tx) = Channel::balance_channel(1024);
                 for i in 0..channel_size.max(1) {
-                    let endpoint = Channel::from_static("https://bigtable.googleapis.com")
-                        .tls_config(
-                            ClientTlsConfig::new()
-                                .ca_certificate(
-                                    root_ca_certificate::load()
-                                        .map_err(Error::CertificateError)
-                                        .expect("root certificate error"),
-                                )
-                                .domain_name("bigtable.googleapis.com"),
-                        )
-                        .map_err(Error::TransportError)?
-                        .http2_keep_alive_interval(Duration::from_secs(60))
-                        .keep_alive_while_idle(true);
-
-                    let endpoint = if let Some(timeout) = timeout {
-                        endpoint.timeout(timeout)
-                    } else {
-                        endpoint
-                    };
-
+                    let endpoint = create_endpoint(timeout)?;
                     // Use unique keys to ensure each channel has a dedicated HTTP connection
                     tx.try_send(Change::Insert(i, endpoint)).unwrap();
                 }
 
                 let token_provider = Some(token_provider);
                 Ok(Self {
-                    client: create_client(channel, token_provider, is_read_only),
+                    client: create_client(box_transport(channel), token_provider, is_read_only),
                     table_prefix: Arc::new(table_prefix),
                     instance_prefix: Arc::new(instance_prefix),
                     timeout: Arc::new(timeout),
+                    _bg_tasks: None,
                 })
             }
         }
@@ -378,7 +388,7 @@ impl BigTableConnection {
         };
 
         Ok(Self {
-            client: create_client(channel, None, is_read_only),
+            client: create_client(box_transport(channel), None, is_read_only),
             table_prefix: Arc::new(format!(
                 "projects/{}/instances/{}/tables/",
                 project_id, instance_name
@@ -388,9 +398,251 @@ impl BigTableConnection {
                 project_id, instance_name
             )),
             timeout: Arc::new(timeout),
+            _bg_tasks: None,
         })
     }
 
+    /// Returns a BigTable connection with a channel pool managed by a background task.
+    ///
+    /// The manager task is responsible for:
+    /// - Optionally pre-emptively refreshing channels every `max_connection_age`
+    /// - Optionally priming channels (both in the initial pool and new ones introduced by
+    ///   refreshes) by sending a [`PingAndWarmRequest`] with the given `app_profile_id` ("default" if None)
+    pub async fn new_with_managed_transport(
+        project_id: &str,
+        instance_name: &str,
+        is_read_only: bool,
+        timeout: Option<Duration>,
+        token_provider: Arc<dyn TokenProvider>,
+        num_channels: usize,
+        prime_channels: bool,
+        app_profile_id: Option<String>,
+        max_channel_age: Option<Duration>,
+    ) -> Result<Self> {
+        let instance_prefix = format!("projects/{project_id}/instances/{instance_name}");
+        let table_prefix = format!("{instance_prefix}/tables/");
+        let endpoint = create_endpoint(timeout)?;
+        let num_channels = num_channels.max(1);
+
+        // Analogous to what `tonic::transport::channel::Channel::balance_channel` constructs
+        // internally.
+        let (tx, rx) = channel(num_channels);
+        let stream = ChannelStream::new(rx);
+        let balance = Balance::new(stream);
+        let (service, worker) = Buffer::pair(balance, 1024);
+
+        let mut background_tasks = tokio::task::JoinSet::new();
+        background_tasks.spawn(worker);
+
+        let mut manager = ChannelManager::new(
+            endpoint,
+            token_provider.clone(),
+            instance_prefix.clone(),
+            num_channels,
+            prime_channels,
+            app_profile_id,
+            max_channel_age,
+            tx,
+        );
+        manager.seed().await?;
+        background_tasks.spawn(async move { manager.run().await });
+
+        Ok(Self {
+            client: create_client(box_transport(service), Some(token_provider), is_read_only),
+            table_prefix: Arc::new(table_prefix),
+            instance_prefix: Arc::new(instance_prefix),
+            timeout: Arc::new(timeout),
+            _bg_tasks: Some(Arc::new(background_tasks)),
+        })
+    }
+}
+
+fn create_endpoint(timeout: Option<Duration>) -> Result<Endpoint> {
+    let endpoint = Channel::from_static("https://bigtable.googleapis.com")
+        .tls_config(
+            ClientTlsConfig::new()
+                .ca_certificate(
+                    root_ca_certificate::load()
+                        .map_err(Error::CertificateError)
+                        .expect("root certificate error"),
+                )
+                .domain_name("bigtable.googleapis.com"),
+        )
+        .map_err(Error::TransportError)?
+        .http2_keep_alive_interval(Duration::from_secs(60))
+        .keep_alive_while_idle(true);
+
+    let endpoint = if let Some(timeout) = timeout {
+        endpoint.timeout(timeout)
+    } else {
+        endpoint
+    };
+
+    Ok(endpoint)
+}
+
+async fn create_channel(
+    endpoint: Endpoint,
+    prime: bool,
+    token_provider: Arc<dyn TokenProvider>,
+    instance_prefix: String,
+    app_profile_id: Option<String>,
+) -> Result<Channel> {
+    if !prime {
+        return Ok(endpoint.connect_lazy());
+    }
+    let channel = endpoint.clone().connect().await?;
+    let mut client = create_client(
+        box_transport(channel.clone()),
+        Some(token_provider.clone()),
+        true,
+    );
+    client
+        .ping_and_warm(PingAndWarmRequest {
+            name: instance_prefix.clone(),
+            app_profile_id: app_profile_id.unwrap_or_else(|| "".to_owned()),
+        })
+        .await?;
+    Ok(channel)
+}
+
+type CountPendingChannel = PendingRequests<Channel, CompleteOnResponse>;
+
+type ChannelChange = TowerChange<usize, CountPendingChannel>;
+
+struct ChannelManager {
+    endpoint: Endpoint,
+    token_provider: Arc<dyn TokenProvider>,
+    instance_prefix: String,
+    num_channels: usize,
+    prime_channels: bool,
+    app_profile_id: Option<String>,
+    max_connection_age: Option<Duration>,
+    change_sender: Sender<ChannelChange>,
+}
+
+impl ChannelManager {
+    fn new(
+        endpoint: Endpoint,
+        token_provider: Arc<dyn TokenProvider>,
+        instance_prefix: String,
+        num_channels: usize,
+        prime_channels: bool,
+        app_profile_id: Option<String>,
+        max_connection_age: Option<Duration>,
+        change_sender: Sender<ChannelChange>,
+    ) -> Self {
+        Self {
+            endpoint,
+            token_provider,
+            instance_prefix,
+            num_channels: num_channels.max(1),
+            prime_channels,
+            app_profile_id,
+            max_connection_age,
+            change_sender,
+        }
+    }
+
+    // Creates the initial channel pool, optionally priming channels.
+    async fn seed(&self) -> Result<()> {
+        for i in 0..self.num_channels {
+            let channel = create_channel(
+                self.endpoint.clone(),
+                self.prime_channels,
+                self.token_provider.clone(),
+                self.instance_prefix.clone(),
+                self.app_profile_id.clone(),
+            )
+            .await?;
+            let channel = PendingRequests::new(channel, CompleteOnResponse::default());
+
+            // Will never error unless the channel is closed
+            self.change_sender
+                .send(ChannelChange::Insert(i, channel))
+                .await
+                .ok();
+        }
+        Ok(())
+    }
+
+    // Pre-emptively refreshes channels every `max_connection_age`, optionally priming them.
+    //
+    // Channel refresh is best-effort.
+    // If creating or priming a channel fails, we log a warning.
+    // In case the pre-emptive refresh fails, causing a channel to stay alive for too long and
+    // eventually be killed by the server, the underlying tonic `Channel` will handle this for us
+    // transparently, but lazily.
+    async fn run(&mut self) {
+        let Some(max_age) = self.max_connection_age else {
+            return;
+        };
+        loop {
+            tokio::time::sleep(max_age).await;
+            debug!("Refreshing {} channels", self.num_channels);
+
+            for i in 0..self.num_channels {
+                let channel = create_channel(
+                    self.endpoint.clone(),
+                    self.prime_channels,
+                    self.token_provider.clone(),
+                    self.instance_prefix.clone(),
+                    self.app_profile_id.clone(),
+                )
+                .await;
+
+                let channel = match channel {
+                    Ok(ch) => ch,
+                    Err(e) => {
+                        warn!("Failed to create channel {i}: {e}");
+                        continue;
+                    }
+                };
+
+                if let Err(e) = self.change_sender.try_send(ChannelChange::Insert(
+                    i,
+                    PendingRequests::new(channel, CompleteOnResponse::default()),
+                )) {
+                    warn!("Failed to send channel change {i}: {e}");
+                }
+            }
+        }
+    }
+}
+
+impl BigTableConnection {}
+
+// Analogous to `tonic::transport::channel::service::discover::DynamicServiceStream`, which `tonic`
+// itself doesn't expose.
+struct ChannelStream {
+    changes: Receiver<ChannelChange>,
+}
+
+impl ChannelStream {
+    pub fn new(changes: Receiver<ChannelChange>) -> Self {
+        Self { changes }
+    }
+}
+
+impl Stream for ChannelStream {
+    type Item = Result<ChannelChange>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.changes).poll_recv(cx) {
+            Poll::Pending | Poll::Ready(None) => Poll::Pending,
+            Poll::Ready(Some(change)) => match change {
+                TowerChange::Insert(k, channel) => {
+                    Poll::Ready(Some(Ok(ChannelChange::Insert(k, channel))))
+                }
+                TowerChange::Remove(k) => Poll::Ready(Some(Ok(ChannelChange::Remove(k)))),
+            },
+        }
+    }
+}
+
+impl Unpin for ChannelStream {}
+
+impl BigTableConnection {
     /// Create a new BigTable client by cloning needed properties.
     ///
     /// Clients require `&mut self`, due to `Tonic::transport::Channel` limitations, however
@@ -401,6 +653,7 @@ impl BigTableConnection {
             instance_prefix: self.instance_prefix.clone(),
             table_prefix: self.table_prefix.clone(),
             timeout: self.timeout.clone(),
+            _bg_tasks: self._bg_tasks.clone(),
         }
     }
 
@@ -413,10 +666,9 @@ impl BigTableConnection {
     }
 }
 
-/// Helper function to create a BigtableClient<AuthSvc>
-/// from a channel.
+/// Helper function to create a BigtableClient<AuthSvc> from a transport.
 fn create_client(
-    channel: Channel,
+    transport: BoxTransport,
     token_provider: Option<Arc<dyn TokenProvider>>,
     read_only: bool,
 ) -> BigtableClient<AuthSvc> {
@@ -428,8 +680,8 @@ fn create_client(
 
     let auth_svc = ServiceBuilder::new()
         .layer_fn(|c| AuthSvc::new(c, token_provider.clone(), scopes.to_string()))
-        .service(channel);
-    return BigtableClient::new(auth_svc);
+        .service(transport);
+    BigtableClient::new(auth_svc)
 }
 
 /// The core struct for Bigtable client, which wraps a gPRC client defined by Bigtable proto.
@@ -456,6 +708,10 @@ pub struct BigTable {
     instance_prefix: Arc<String>,
     table_prefix: Arc<String>,
     timeout: Arc<Option<Duration>>,
+    // Arc that holds a reference to the _bg_tasks from the BigTableConnection this was created from.
+    // This is needed as we want to keep the tasks alive even if the user drops the BigTableConnection
+    // this BigTable instance originated from.
+    _bg_tasks: Option<Arc<tokio::task::JoinSet<()>>>,
 }
 
 impl BigTable {

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -92,31 +92,18 @@ use std::time::Duration;
 
 use futures_util::Stream;
 use gcp_auth::TokenProvider;
-use http::{Request as HttpRequest, Response as HttpResponse};
-use log::{debug, info, warn};
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
-};
+use log::info;
 use thiserror::Error;
 use tokio::net::UnixStream;
-use tokio::sync::mpsc::Receiver;
-use tokio::sync::mpsc::{channel, Sender};
-use tonic::body::Body;
 use tonic::metadata::MetadataValue;
-use tonic::transport::channel::Change;
 use tonic::transport::Endpoint;
 use tonic::IntoRequest;
 use tonic::{
     codec::Streaming,
-    transport::{Channel, ClientTlsConfig},
+    transport::Channel,
     Response,
 };
-use tower::load::{CompleteOnResponse, PendingRequests};
-use tower::util::ServiceExt;
-use tower::{balance::p2c::Balance, buffer::Buffer};
-use tower::{discover::Change as TowerChange, util::BoxCloneSyncService};
-use tower::{BoxError, Service, ServiceBuilder};
+use tower::ServiceBuilder;
 
 use crate::auth_service::AuthSvc;
 use crate::bigtable::read_rows::{decode_read_rows_response, decode_read_rows_response_stream};
@@ -126,16 +113,16 @@ use crate::google::bigtable::v2::{
 };
 use crate::google::bigtable::v2::{
     CheckAndMutateRowRequest, CheckAndMutateRowResponse, ExecuteQueryRequest, ExecuteQueryResponse,
-    PingAndWarmRequest,
 };
-use crate::{root_ca_certificate, util::get_row_range_from_prefix};
+use crate::transport::{box_transport, BoxTransport, ManagedTransportBuilder, create_endpoint};
+use crate::util::get_row_range_from_prefix;
 
 pub mod read_rows;
 
 /// An alias for Vec<u8> as row key
 type RowKey = Vec<u8>;
 /// A convenient Result type
-type Result<T> = std::result::Result<T, Error>;
+pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 /// A data structure for returning the read content of a cell in a row.
 #[derive(Debug)]
@@ -208,43 +195,6 @@ impl std::convert::From<tonic::Status> for Error {
     }
 }
 
-/// The underlying `tower::Service` used to dispatch HTTP requests.
-pub(crate) type BoxTransport = BoxCloneSyncService<HttpRequest<Body>, HttpResponse<Body>, BoxError>;
-
-fn box_transport<T>(transport: T) -> BoxTransport
-where
-    T: Service<HttpRequest<Body>, Response = HttpResponse<Body>> + Clone + Send + Sync + 'static,
-    T::Error: Into<BoxError>,
-    T::Future: Send + 'static,
-{
-    BoxTransport::new(transport.map_err(Into::into))
-}
-
-/// A wrapper around a `Service` that holds background tasks alive via an `Arc<JoinSet>`.
-/// When the last clone is dropped, all background tasks are aborted.
-#[derive(Clone)]
-struct ManagedTransport<T> {
-    inner: T,
-    _bg_tasks: Arc<tokio::task::JoinSet<()>>,
-}
-
-impl<T, Req> Service<Req> for ManagedTransport<T>
-where
-    T: Service<Req>,
-{
-    type Response = T::Response;
-    type Error = T::Error;
-    type Future = T::Future;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: Req) -> Self::Future {
-        self.inner.call(req)
-    }
-}
-
 /// For initiate a Bigtable connection, then a `Bigtable` client can be made from it.
 #[derive(Clone)]
 pub struct BigTableConnection {
@@ -288,7 +238,8 @@ impl BigTableConnection {
                 instance_name,
                 is_read_only,
                 timeout,
-            ),
+            )
+            .await,
 
             Err(_) => {
                 let token_provider = gcp_auth::provider().await?;
@@ -300,9 +251,11 @@ impl BigTableConnection {
                     timeout,
                     token_provider,
                 )
+                .await
             }
         }
     }
+
     /// Establish a connection to the BigTable instance named `instance_name`. If read-only access
     /// is required, the `read_only` flag should be used to reduce the requested OAuth2 scope.
     ///
@@ -314,7 +267,7 @@ impl BigTableConnection {
     /// Consult the [Bigtable
     /// docs](https://docs.cloud.google.com/bigtable/docs/configure-connection-pools) for guidance
     /// on how to determine the optimal pool size for your application.
-    pub fn new_with_token_provider(
+    pub async fn new_with_token_provider(
         project_id: &str,
         instance_name: &str,
         is_read_only: bool,
@@ -329,26 +282,23 @@ impl BigTableConnection {
                 instance_name,
                 is_read_only,
                 timeout,
-            ),
+            )
+            .await,
 
             Err(_) => {
-                let instance_prefix = format!("projects/{project_id}/instances/{instance_name}");
-                let table_prefix = format!("{instance_prefix}/tables/");
-
-                let (channel, tx) = Channel::balance_channel(1024);
-                for i in 0..channel_size.max(1) {
-                    let endpoint = create_endpoint(timeout)?;
-                    // Use unique keys to ensure each channel has a dedicated HTTP connection
-                    tx.try_send(Change::Insert(i, endpoint)).unwrap();
-                }
-
-                let token_provider = Some(token_provider);
-                Ok(Self {
-                    client: create_client(box_transport(channel), token_provider, is_read_only),
-                    table_prefix: Arc::new(table_prefix),
-                    instance_prefix: Arc::new(instance_prefix),
-                    timeout: Arc::new(timeout),
-                })
+                let endpoint = create_endpoint(timeout)?;
+                let transport = ManagedTransportBuilder::new(endpoint)
+                    .num_channels(channel_size)
+                    .build()
+                    .await?;
+                Ok(Self::new_with_transport(
+                    project_id,
+                    instance_name,
+                    is_read_only,
+                    timeout,
+                    Some(token_provider),
+                    transport,
+                ))
             }
         }
     }
@@ -358,7 +308,7 @@ impl BigTableConnection {
     /// which both support the `BIGTABLE_EMULATOR_HOST` env variable. However,
     /// this function can also be used directly, in case setting
     /// `BIGTABLE_EMULATOR_HOST` is inconvenient.
-    pub fn new_with_emulator(
+    pub async fn new_with_emulator(
         emulator_endpoint: &str,
         project_id: &str,
         instance_name: &str,
@@ -384,7 +334,7 @@ impl BigTableConnection {
         // but unix:///path/to/unix.sock also works in the Go SDK at least.
         // Having the emulator listen on unix domain sockets without ip2unix is
         // covered in https://github.com/googleapis/google-cloud-go/pull/9665.
-        let channel = if let Some(path) = emulator_endpoint.strip_prefix("unix://") {
+        let transport = if let Some(path) = emulator_endpoint.strip_prefix("unix://") {
             // the URL doesn't matter, we use a custom connector.
             let endpoint = Endpoint::from_static("http://[::]:50051");
             let endpoint = configure_endpoint(endpoint, timeout);
@@ -400,270 +350,47 @@ impl BigTableConnection {
                 }
             });
 
-            endpoint.connect_with_connector_lazy(connector)
+            box_transport(endpoint.connect_with_connector_lazy(connector))
         } else {
             let endpoint = Channel::from_shared(format!("http://{}", emulator_endpoint))
                 .expect("invalid connection emulator uri");
             let endpoint = configure_endpoint(endpoint, timeout);
 
-            endpoint.connect_lazy()
+            ManagedTransportBuilder::new(endpoint)
+                .build()
+                .await?
         };
 
-        Ok(Self {
-            client: create_client(box_transport(channel), None, is_read_only),
-            table_prefix: Arc::new(format!(
-                "projects/{}/instances/{}/tables/",
-                project_id, instance_name
-            )),
-            instance_prefix: Arc::new(format!(
-                "projects/{}/instances/{}",
-                project_id, instance_name
-            )),
-            timeout: Arc::new(timeout),
-        })
+        Ok(Self::new_with_transport(
+            project_id,
+            instance_name,
+            is_read_only,
+            timeout,
+            None,
+            transport,
+        ))
     }
 
-    /// Returns a BigTable connection with a channel pool managed by a background task.
-    ///
-    /// The manager task is responsible for:
-    /// - Optionally pre-emptively refreshing channels every `max_connection_age`
-    /// - Optionally priming channels (both in the initial pool and new ones introduced by
-    ///   refreshes) by sending a [`PingAndWarmRequest`] with the given `app_profile_id` ("default" if None)
-    pub async fn new_with_managed_transport(
+    /// Create a `BigTableConnection` from a pre-built transport.
+    pub fn new_with_transport(
         project_id: &str,
         instance_name: &str,
         is_read_only: bool,
         timeout: Option<Duration>,
-        token_provider: Arc<dyn TokenProvider>,
-        num_channels: usize,
-        prime_channels: bool,
-        app_profile_id: Option<String>,
-        max_channel_age: Option<Duration>,
-    ) -> Result<Self> {
+        token_provider: Option<Arc<dyn TokenProvider>>,
+        transport: BoxTransport,
+    ) -> Self {
         let instance_prefix = format!("projects/{project_id}/instances/{instance_name}");
         let table_prefix = format!("{instance_prefix}/tables/");
-        let endpoint = create_endpoint(timeout)?;
-        let num_channels = num_channels.max(1);
 
-        // Analogous to what `tonic::transport::channel::Channel::balance_channel` constructs
-        // internally.
-        let (tx, rx) = channel(num_channels);
-        let stream = ChannelStream::new(rx);
-        let balance = Balance::new(stream);
-        let (service, worker) = Buffer::pair(balance, 1024);
-
-        let mut background_tasks = tokio::task::JoinSet::new();
-        background_tasks.spawn(worker);
-
-        let mut manager = ChannelManager::new(
-            endpoint,
-            token_provider.clone(),
-            instance_prefix.clone(),
-            num_channels,
-            prime_channels,
-            app_profile_id,
-            max_channel_age,
-            tx,
-        );
-        manager.seed().await?;
-        background_tasks.spawn(async move { manager.run().await });
-
-        let transport = ManagedTransport {
-            inner: service,
-            _bg_tasks: Arc::new(background_tasks),
-        };
-
-        Ok(Self {
-            client: create_client(box_transport(transport), Some(token_provider), is_read_only),
+        Self {
+            client: create_client(transport, token_provider, is_read_only),
             table_prefix: Arc::new(table_prefix),
             instance_prefix: Arc::new(instance_prefix),
             timeout: Arc::new(timeout),
-        })
-    }
-}
-
-fn create_endpoint(timeout: Option<Duration>) -> Result<Endpoint> {
-    let endpoint = Channel::from_static("https://bigtable.googleapis.com")
-        .tls_config(
-            ClientTlsConfig::new()
-                .ca_certificate(
-                    root_ca_certificate::load()
-                        .map_err(Error::CertificateError)
-                        .expect("root certificate error"),
-                )
-                .domain_name("bigtable.googleapis.com"),
-        )
-        .map_err(Error::TransportError)?
-        .http2_keep_alive_interval(Duration::from_secs(60))
-        .keep_alive_while_idle(true);
-
-    let endpoint = if let Some(timeout) = timeout {
-        endpoint.timeout(timeout)
-    } else {
-        endpoint
-    };
-
-    Ok(endpoint)
-}
-
-async fn create_channel(
-    endpoint: Endpoint,
-    prime: bool,
-    token_provider: Arc<dyn TokenProvider>,
-    instance_prefix: String,
-    app_profile_id: Option<String>,
-) -> Result<Channel> {
-    if !prime {
-        return Ok(endpoint.connect_lazy());
-    }
-    let channel = endpoint.clone().connect().await?;
-    let mut client = create_client(
-        box_transport(channel.clone()),
-        Some(token_provider.clone()),
-        true,
-    );
-    client
-        .ping_and_warm(PingAndWarmRequest {
-            name: instance_prefix.clone(),
-            app_profile_id: app_profile_id.unwrap_or_else(|| "".to_owned()),
-        })
-        .await?;
-    Ok(channel)
-}
-
-type CountPendingChannel = PendingRequests<Channel, CompleteOnResponse>;
-
-type ChannelChange = TowerChange<usize, CountPendingChannel>;
-
-struct ChannelManager {
-    endpoint: Endpoint,
-    token_provider: Arc<dyn TokenProvider>,
-    instance_prefix: String,
-    num_channels: usize,
-    prime_channels: bool,
-    app_profile_id: Option<String>,
-    max_connection_age: Option<Duration>,
-    change_sender: Sender<ChannelChange>,
-}
-
-impl ChannelManager {
-    fn new(
-        endpoint: Endpoint,
-        token_provider: Arc<dyn TokenProvider>,
-        instance_prefix: String,
-        num_channels: usize,
-        prime_channels: bool,
-        app_profile_id: Option<String>,
-        max_connection_age: Option<Duration>,
-        change_sender: Sender<ChannelChange>,
-    ) -> Self {
-        Self {
-            endpoint,
-            token_provider,
-            instance_prefix,
-            num_channels: num_channels.max(1),
-            prime_channels,
-            app_profile_id,
-            max_connection_age,
-            change_sender,
-        }
-    }
-
-    // Creates the initial channel pool, optionally priming channels.
-    async fn seed(&self) -> Result<()> {
-        for i in 0..self.num_channels {
-            let channel = create_channel(
-                self.endpoint.clone(),
-                self.prime_channels,
-                self.token_provider.clone(),
-                self.instance_prefix.clone(),
-                self.app_profile_id.clone(),
-            )
-            .await?;
-            let channel = PendingRequests::new(channel, CompleteOnResponse::default());
-
-            // Will never error unless the channel is closed
-            self.change_sender
-                .send(ChannelChange::Insert(i, channel))
-                .await
-                .ok();
-        }
-        Ok(())
-    }
-
-    // Pre-emptively refreshes channels every `max_connection_age`, optionally priming them.
-    //
-    // Channel refresh is best-effort.
-    // If creating or priming a channel fails, we log a warning.
-    // In case the pre-emptive refresh fails, causing a channel to stay alive for too long and
-    // eventually be killed by the server, the underlying tonic `Channel` will handle this for us
-    // transparently, but lazily.
-    async fn run(&mut self) {
-        let Some(max_age) = self.max_connection_age else {
-            return;
-        };
-        loop {
-            tokio::time::sleep(max_age).await;
-            debug!("Refreshing {} channels", self.num_channels);
-
-            for i in 0..self.num_channels {
-                let channel = create_channel(
-                    self.endpoint.clone(),
-                    self.prime_channels,
-                    self.token_provider.clone(),
-                    self.instance_prefix.clone(),
-                    self.app_profile_id.clone(),
-                )
-                .await;
-
-                let channel = match channel {
-                    Ok(ch) => ch,
-                    Err(e) => {
-                        warn!("Failed to create channel {i}: {e}");
-                        continue;
-                    }
-                };
-
-                if let Err(e) = self.change_sender.try_send(ChannelChange::Insert(
-                    i,
-                    PendingRequests::new(channel, CompleteOnResponse::default()),
-                )) {
-                    warn!("Failed to send channel change {i}: {e}");
-                }
-            }
         }
     }
 }
-
-// Analogous to `tonic::transport::channel::service::discover::DynamicServiceStream`, which `tonic`
-// itself doesn't expose.
-struct ChannelStream {
-    changes: Receiver<ChannelChange>,
-}
-
-impl ChannelStream {
-    pub fn new(changes: Receiver<ChannelChange>) -> Self {
-        Self { changes }
-    }
-}
-
-impl Stream for ChannelStream {
-    type Item = Result<ChannelChange>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match Pin::new(&mut self.changes).poll_recv(cx) {
-            Poll::Pending | Poll::Ready(None) => Poll::Pending,
-            Poll::Ready(Some(change)) => match change {
-                TowerChange::Insert(k, channel) => {
-                    Poll::Ready(Some(Ok(ChannelChange::Insert(k, channel))))
-                }
-                TowerChange::Remove(k) => Poll::Ready(Some(Ok(ChannelChange::Remove(k)))),
-            },
-        }
-    }
-}
-
-impl Unpin for ChannelStream {}
 
 impl BigTableConnection {
     /// Create a new BigTable client by cloning needed properties.
@@ -689,7 +416,7 @@ impl BigTableConnection {
 }
 
 /// Helper function to create a BigtableClient<AuthSvc> from a transport.
-fn create_client(
+pub(crate) fn create_client(
     transport: BoxTransport,
     token_provider: Option<Arc<dyn TokenProvider>>,
     read_only: bool,

--- a/bigtable_rs/src/lib.rs
+++ b/bigtable_rs/src/lib.rs
@@ -11,6 +11,7 @@ mod auth_service;
 pub mod bigtable;
 pub mod google;
 mod root_ca_certificate;
+pub mod transport;
 pub mod util;
 
 #[cfg(test)]

--- a/bigtable_rs/src/transport.rs
+++ b/bigtable_rs/src/transport.rs
@@ -1,0 +1,351 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_util::Stream;
+use gcp_auth::TokenProvider;
+use http::{Request as HttpRequest, Response as HttpResponse};
+use log::{debug, warn};
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tonic::body::Body;
+use tonic::transport::channel::Change;
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use tower::load::{CompleteOnResponse, PendingRequests};
+use tower::util::ServiceExt;
+use tower::{balance::p2c::Balance, buffer::Buffer};
+use tower::{discover::Change as TowerChange, util::BoxCloneSyncService};
+use tower::{BoxError, Service};
+
+use crate::bigtable::{create_client, Error, Result};
+use crate::google::bigtable::v2::PingAndWarmRequest;
+use crate::root_ca_certificate;
+
+/// The underlying `tower::Service` used to dispatch HTTP requests.
+pub type BoxTransport = BoxCloneSyncService<HttpRequest<Body>, HttpResponse<Body>, BoxError>;
+
+pub fn box_transport<T>(transport: T) -> BoxTransport
+where
+    T: Service<HttpRequest<Body>, Response = HttpResponse<Body>> + Clone + Send + Sync + 'static,
+    T::Error: Into<BoxError>,
+    T::Future: Send + 'static,
+{
+    BoxTransport::new(transport.map_err(Into::into))
+}
+
+pub fn create_endpoint(timeout: Option<Duration>) -> Result<Endpoint> {
+    let endpoint = Channel::from_static("https://bigtable.googleapis.com")
+        .tls_config(
+            ClientTlsConfig::new()
+                .ca_certificate(
+                    root_ca_certificate::load()
+                        .map_err(Error::CertificateError)
+                        .expect("root certificate error"),
+                )
+                .domain_name("bigtable.googleapis.com"),
+        )
+        .map_err(Error::TransportError)?
+        .http2_keep_alive_interval(Duration::from_secs(60))
+        .keep_alive_while_idle(true);
+
+    let endpoint = if let Some(timeout) = timeout {
+        endpoint.timeout(timeout)
+    } else {
+        endpoint
+    };
+
+    Ok(endpoint)
+}
+
+pub async fn create_channel(
+    endpoint: Endpoint,
+    prime: bool,
+    token_provider: Arc<dyn TokenProvider>,
+    instance_prefix: String,
+    app_profile_id: Option<String>,
+) -> Result<Channel> {
+    if !prime {
+        return Ok(endpoint.connect_lazy());
+    }
+    let channel = endpoint.clone().connect().await?;
+    let mut client = create_client(
+        box_transport(channel.clone()),
+        Some(token_provider.clone()),
+        true,
+    );
+    client
+        .ping_and_warm(PingAndWarmRequest {
+            name: instance_prefix.clone(),
+            app_profile_id: app_profile_id.unwrap_or_else(|| "".to_owned()),
+        })
+        .await?;
+    Ok(channel)
+}
+
+/// Builder for creating a `BoxTransport` backed by a managed channel pool.
+pub struct ManagedTransportBuilder {
+    endpoint: Endpoint,
+    num_channels: usize,
+    token_provider: Option<Arc<dyn TokenProvider>>,
+    instance_prefix: Option<String>,
+    prime_channels: bool,
+    app_profile_id: Option<String>,
+    max_channel_age: Option<Duration>,
+}
+
+impl ManagedTransportBuilder {
+    pub fn new(endpoint: Endpoint) -> Self {
+        Self {
+            endpoint,
+            num_channels: 1,
+            token_provider: None,
+            instance_prefix: None,
+            prime_channels: false,
+            app_profile_id: None,
+            max_channel_age: None,
+        }
+    }
+
+    pub fn num_channels(mut self, n: usize) -> Self {
+        self.num_channels = n;
+        self
+    }
+
+    pub fn token_provider(mut self, tp: Arc<dyn TokenProvider>) -> Self {
+        self.token_provider = Some(tp);
+        self
+    }
+
+    pub fn instance_prefix(mut self, prefix: String) -> Self {
+        self.instance_prefix = Some(prefix);
+        self
+    }
+
+    pub fn prime_channels(mut self, prime: bool) -> Self {
+        self.prime_channels = prime;
+        self
+    }
+
+    pub fn app_profile_id(mut self, id: String) -> Self {
+        self.app_profile_id = Some(id);
+        self
+    }
+
+    pub fn max_channel_age(mut self, age: Duration) -> Self {
+        self.max_channel_age = Some(age);
+        self
+    }
+
+    pub async fn build(self) -> Result<BoxTransport> {
+        let num_channels = self.num_channels.max(1);
+
+        // If we don't need priming or refresh, use tonic's built-in balance_channel
+        // which is simpler and doesn't require a token_provider or instance_prefix.
+        if !self.prime_channels && self.max_channel_age.is_none() {
+            let (channel, tx) = Channel::balance_channel(1024);
+            for i in 0..num_channels {
+                let endpoint = self.endpoint.clone();
+                tx.try_send(Change::Insert(i, endpoint)).unwrap();
+            }
+            return Ok(box_transport(channel));
+        }
+
+        // Full managed path: requires token_provider and instance_prefix for priming/refresh.
+        let token_provider = self
+            .token_provider
+            .expect("token_provider is required when prime_channels or max_channel_age is set");
+        let instance_prefix = self
+            .instance_prefix
+            .expect("instance_prefix is required when prime_channels or max_channel_age is set");
+
+        let (tx, rx) = channel(num_channels);
+        let stream = ChannelStream::new(rx);
+        let balance = Balance::new(stream);
+        let (service, worker) = Buffer::pair(balance, 1024);
+
+        let mut background_tasks = tokio::task::JoinSet::new();
+        background_tasks.spawn(worker);
+
+        let mut manager = ChannelManager::new(
+            self.endpoint,
+            token_provider,
+            instance_prefix,
+            num_channels,
+            self.prime_channels,
+            self.app_profile_id,
+            self.max_channel_age,
+            tx,
+        );
+        manager.seed().await?;
+        background_tasks.spawn(async move { manager.run().await });
+
+        let transport = ManagedTransport {
+            inner: service,
+            _bg_tasks: Arc::new(background_tasks),
+        };
+
+        Ok(box_transport(transport))
+    }
+}
+
+/// A wrapper around a `Service` that holds background tasks alive via an `Arc<JoinSet>`.
+/// When the last clone is dropped, all background tasks are aborted.
+#[derive(Clone)]
+struct ManagedTransport<T> {
+    inner: T,
+    _bg_tasks: Arc<tokio::task::JoinSet<()>>,
+}
+
+impl<T, Req> Service<Req> for ManagedTransport<T>
+where
+    T: Service<Req>,
+{
+    type Response = T::Response;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
+type CountPendingChannel = PendingRequests<Channel, CompleteOnResponse>;
+
+type ChannelChange = TowerChange<usize, CountPendingChannel>;
+
+struct ChannelManager {
+    endpoint: Endpoint,
+    token_provider: Arc<dyn TokenProvider>,
+    instance_prefix: String,
+    num_channels: usize,
+    prime_channels: bool,
+    app_profile_id: Option<String>,
+    max_connection_age: Option<Duration>,
+    change_sender: Sender<ChannelChange>,
+}
+
+impl ChannelManager {
+    fn new(
+        endpoint: Endpoint,
+        token_provider: Arc<dyn TokenProvider>,
+        instance_prefix: String,
+        num_channels: usize,
+        prime_channels: bool,
+        app_profile_id: Option<String>,
+        max_connection_age: Option<Duration>,
+        change_sender: Sender<ChannelChange>,
+    ) -> Self {
+        Self {
+            endpoint,
+            token_provider,
+            instance_prefix,
+            num_channels: num_channels.max(1),
+            prime_channels,
+            app_profile_id,
+            max_connection_age,
+            change_sender,
+        }
+    }
+
+    // Creates the initial channel pool, optionally priming channels.
+    async fn seed(&self) -> Result<()> {
+        for i in 0..self.num_channels {
+            let channel = create_channel(
+                self.endpoint.clone(),
+                self.prime_channels,
+                self.token_provider.clone(),
+                self.instance_prefix.clone(),
+                self.app_profile_id.clone(),
+            )
+            .await?;
+            let channel = PendingRequests::new(channel, CompleteOnResponse::default());
+
+            // Will never error unless the channel is closed
+            self.change_sender
+                .send(ChannelChange::Insert(i, channel))
+                .await
+                .ok();
+        }
+        Ok(())
+    }
+
+    // Pre-emptively refreshes channels every `max_connection_age`, optionally priming them.
+    //
+    // Channel refresh is best-effort.
+    // If creating or priming a channel fails, we log a warning.
+    // In case the pre-emptive refresh fails, causing a channel to stay alive for too long and
+    // eventually be killed by the server, the underlying tonic `Channel` will handle this for us
+    // transparently, but lazily.
+    async fn run(&mut self) {
+        let Some(max_age) = self.max_connection_age else {
+            return;
+        };
+        loop {
+            tokio::time::sleep(max_age).await;
+            debug!("Refreshing {} channels", self.num_channels);
+
+            for i in 0..self.num_channels {
+                let channel = create_channel(
+                    self.endpoint.clone(),
+                    self.prime_channels,
+                    self.token_provider.clone(),
+                    self.instance_prefix.clone(),
+                    self.app_profile_id.clone(),
+                )
+                .await;
+
+                let channel = match channel {
+                    Ok(ch) => ch,
+                    Err(e) => {
+                        warn!("Failed to create channel {i}: {e}");
+                        continue;
+                    }
+                };
+
+                if let Err(e) = self.change_sender.try_send(ChannelChange::Insert(
+                    i,
+                    PendingRequests::new(channel, CompleteOnResponse::default()),
+                )) {
+                    warn!("Failed to send channel change {i}: {e}");
+                }
+            }
+        }
+    }
+}
+
+// Analogous to `tonic::transport::channel::service::discover::DynamicServiceStream`, which `tonic`
+// itself doesn't expose.
+struct ChannelStream {
+    changes: Receiver<ChannelChange>,
+}
+
+impl ChannelStream {
+    pub fn new(changes: Receiver<ChannelChange>) -> Self {
+        Self { changes }
+    }
+}
+
+impl Stream for ChannelStream {
+    type Item = Result<ChannelChange>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.changes).poll_recv(cx) {
+            Poll::Pending | Poll::Ready(None) => Poll::Pending,
+            Poll::Ready(Some(change)) => match change {
+                TowerChange::Insert(k, channel) => {
+                    Poll::Ready(Some(Ok(ChannelChange::Insert(k, channel))))
+                }
+                TowerChange::Remove(k) => Poll::Ready(Some(Ok(ChannelChange::Remove(k)))),
+            },
+        }
+    }
+}
+
+impl Unpin for ChannelStream {}

--- a/examples/src/configure_inner_client.rs
+++ b/examples/src/configure_inner_client.rs
@@ -24,7 +24,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         channel_size,
         Some(timeout),
         Arc::new(CustomServiceAccount::from_file(json_path).unwrap()),
-    )?;
+    )
+    .await?;
 
     // update the config for the inner client of the connection
     connection

--- a/examples/src/custom_path_connection.rs
+++ b/examples/src/custom_path_connection.rs
@@ -32,7 +32,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         channel_size,
         Some(timeout),
         Arc::new(CustomServiceAccount::from_file(json_path).unwrap()),
-    )?;
+    )
+    .await?;
     let mut bigtable = connection.client();
 
     let request = MutateRowRequest {


### PR DESCRIPTION
Extract all transport-related types (`BoxTransport`, `ManagedTransport`, `ChannelManager`, `ChannelStream`) from the 865-line `bigtable.rs` into a new `transport.rs` module. This reduces `bigtable.rs` to ~480 lines focused on the BigTable client API.

Introduces `ManagedTransportBuilder` for configuring managed channel pools (num_channels, priming, refresh, app_profile_id), and a generic `new_with_transport(BoxTransport)` constructor that all existing codepaths now use internally. The simple path (no priming/refresh) uses tonic's built-in `balance_channel`, while the full managed path uses the existing `ChannelManager` + `Buffer`/`Balance` stack.

**Breaking changes:**
- `new_with_token_provider` and `new_with_emulator` are now `async`
- `new_with_managed_transport` is removed — use `ManagedTransportBuilder` + `new_with_transport` instead
- `BoxTransport` moved from `crate::bigtable` to `crate::transport` (now `pub`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)