### PR TITLE
feat: Align HTTP/2 keepalive config with official clients

### DIFF
--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -310,7 +310,8 @@ impl BigTableConnection {
                                 .domain_name("bigtable.googleapis.com"),
                         )
                         .map_err(Error::TransportError)?
-                        .http2_keep_alive_interval(Duration::from_secs(60))
+                        .http2_keep_alive_interval(Duration::from_secs(30))
+                        .keep_alive_timeout(Duration::from_secs(10))
                         .keep_alive_while_idle(true);
 
                     let endpoint = if let Some(timeout) = timeout {
@@ -352,7 +353,8 @@ impl BigTableConnection {
         // configures the endpoint with the specified parameters
         fn configure_endpoint(endpoint: Endpoint, timeout: Option<Duration>) -> Endpoint {
             let endpoint = endpoint
-                .http2_keep_alive_interval(Duration::from_secs(60))
+                .http2_keep_alive_interval(Duration::from_secs(30))
+                .keep_alive_timeout(Duration::from_secs(10))
                 .keep_alive_while_idle(true);
 
             if let Some(timeout) = timeout {


### PR DESCRIPTION
Sets the HTTP/2 keepalive interval to 30s and the keepalive ACK timeout to 10s.

This aligns bigtable_rs with the official java, php, ruby clients, as documented here https://github.com/googleapis/google-cloud-ruby/issues/8172.