### PR TITLE
feat(bigtable): support AIP-4222 for all Bigtable methods

### DIFF
--- a/bigtable_rs/Cargo.toml
+++ b/bigtable_rs/Cargo.toml
@@ -25,6 +25,7 @@ futures-util = "0.3.31"
 gcp_auth = "0.12.2"
 log = "0.4.20"
 thiserror = "2.0.3"
+urlencoding = "2.1.3"
 
 [features]
 default = ["tonic-tls-aws-lc"]

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -535,18 +535,6 @@ pub struct BigTable {
 }
 
 impl BigTable {
-    /// Helper to attach `x-goog-request-params` header for table APIs
-    fn add_routing_header<T: RoutingMetadata>(
-        mut tonic_req: tonic::Request<T>,
-    ) -> Result<tonic::Request<T>> {
-        let header_val = tonic_req.get_ref().get_routing_header();
-        tonic_req.metadata_mut().insert(
-            "x-goog-request-params",
-            MetadataValue::from_str(&header_val).map_err(Error::MetadataError)?,
-        );
-        Ok(tonic_req)
-    }
-
     /// Wrapped `check_and_mutate_row` method
     pub async fn check_and_mutate_row(
         &mut self,
@@ -690,6 +678,18 @@ impl BigTable {
     /// Provide a convenient method to get full table, which can be used for building requests
     pub fn get_full_table_name(&self, table_name: &str) -> String {
         [&self.table_prefix, table_name].concat()
+    }
+
+    /// Helper to attach `x-goog-request-params` header for table APIs
+    fn add_routing_header<T: RoutingMetadata>(
+        mut tonic_req: tonic::Request<T>,
+    ) -> Result<tonic::Request<T>> {
+        let header_val = tonic_req.get_ref().get_routing_header();
+        tonic_req.metadata_mut().insert(
+            "x-goog-request-params",
+            MetadataValue::from_str(&header_val).map_err(Error::MetadataError)?,
+        );
+        Ok(tonic_req)
     }
 }
 

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -481,14 +481,37 @@ pub struct BigTable {
 }
 
 impl BigTable {
+    /// Helper to attach `x-goog-request-params` header for table APIs
+    fn add_routing_header<T>(
+        mut tonic_req: tonic::Request<T>,
+        table_name: &str,
+        app_profile_id: &str,
+    ) -> Result<tonic::Request<T>> {
+        let header_val = format!(
+            "table_name={}&app_profile_id={}",
+            urlencoding::encode(table_name),
+            urlencoding::encode(app_profile_id)
+        );
+        tonic_req.metadata_mut().insert(
+            "x-goog-request-params",
+            MetadataValue::from_str(&header_val).map_err(Error::MetadataError)?,
+        );
+        Ok(tonic_req)
+    }
+
     /// Wrapped `check_and_mutate_row` method
     pub async fn check_and_mutate_row(
         &mut self,
         request: CheckAndMutateRowRequest,
     ) -> Result<CheckAndMutateRowResponse> {
+        let table_name = request.table_name.clone();
+        let app_profile_id = request.app_profile_id.clone();
+        let tonic_req =
+            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+
         let response = self
             .client
-            .check_and_mutate_row(request)
+            .check_and_mutate_row(tonic_req)
             .await?
             .into_inner();
         Ok(response)
@@ -499,7 +522,11 @@ impl BigTable {
         &mut self,
         request: ReadRowsRequest,
     ) -> Result<Vec<(RowKey, Vec<RowCell>)>> {
-        let response = self.client.read_rows(request).await?.into_inner();
+        let table_name = request.table_name.clone();
+        let app_profile_id = request.app_profile_id.clone();
+        let tonic_req =
+            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let response = self.client.read_rows(tonic_req).await?.into_inner();
         decode_read_rows_response(self.timeout.as_ref(), response).await
     }
 
@@ -514,7 +541,12 @@ impl BigTable {
             row_keys: vec![], // use this field to put keys for reading specific rows
             row_ranges: vec![row_range],
         });
-        let response = self.client.read_rows(request).await?.into_inner();
+
+        let table_name = request.table_name.clone();
+        let app_profile_id = request.app_profile_id.clone();
+        let tonic_req =
+            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let response = self.client.read_rows(tonic_req).await?.into_inner();
         decode_read_rows_response(self.timeout.as_ref(), response).await
     }
 
@@ -523,7 +555,12 @@ impl BigTable {
         &mut self,
         request: ReadRowsRequest,
     ) -> Result<impl Stream<Item = Result<(RowKey, Vec<RowCell>)>>> {
-        let response = self.client.read_rows(request).await?.into_inner();
+        let table_name = request.table_name.clone();
+        let app_profile_id = request.app_profile_id.clone();
+        let tonic_req =
+            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+
+        let response = self.client.read_rows(tonic_req).await?.into_inner();
         let stream = decode_read_rows_response_stream(response).await;
         Ok(stream)
     }
@@ -539,7 +576,13 @@ impl BigTable {
             row_keys: vec![],
             row_ranges: vec![row_range],
         });
-        let response = self.client.read_rows(request).await?.into_inner();
+
+        let table_name = request.table_name.clone();
+        let app_profile_id = request.app_profile_id.clone();
+        let tonic_req =
+            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+
+        let response = self.client.read_rows(tonic_req).await?.into_inner();
         let stream = decode_read_rows_response_stream(response).await;
         Ok(stream)
     }
@@ -549,7 +592,12 @@ impl BigTable {
         &mut self,
         request: SampleRowKeysRequest,
     ) -> Result<Streaming<SampleRowKeysResponse>> {
-        let response = self.client.sample_row_keys(request).await?.into_inner();
+        let table_name = request.table_name.clone();
+        let app_profile_id = request.app_profile_id.clone();
+        let tonic_req =
+            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+
+        let response = self.client.sample_row_keys(tonic_req).await?.into_inner();
         Ok(response)
     }
 
@@ -558,7 +606,12 @@ impl BigTable {
         &mut self,
         request: MutateRowRequest,
     ) -> Result<Response<MutateRowResponse>> {
-        let response = self.client.mutate_row(request).await?;
+        let table_name = request.table_name.clone();
+        let app_profile_id = request.app_profile_id.clone();
+        let tonic_req =
+            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+
+        let response = self.client.mutate_row(tonic_req).await?;
         Ok(response)
     }
 
@@ -567,7 +620,12 @@ impl BigTable {
         &mut self,
         request: MutateRowsRequest,
     ) -> Result<Streaming<MutateRowsResponse>> {
-        let response = self.client.mutate_rows(request).await?.into_inner();
+        let table_name = request.table_name.clone();
+        let app_profile_id = request.app_profile_id.clone();
+        let tonic_req =
+            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+
+        let response = self.client.mutate_rows(tonic_req).await?.into_inner();
         Ok(response)
     }
 
@@ -608,5 +666,90 @@ impl BigTable {
     /// Provide a convenient method to get full table, which can be used for building requests
     pub fn get_full_table_name(&self, table_name: &str) -> String {
         [&self.table_prefix, table_name].concat()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Request;
+
+    #[test]
+    fn test_add_routing_header_standard() {
+        // 1. Setup a dummy request
+        let req = Request::new(());
+
+        // 2. Define standard inputs (notice the slashes that need encoding)
+        let table_name = "projects/my-project/instances/my-instance/tables/my-table";
+        let app_profile_id = "default";
+
+        // 3. Call the function
+        let result = BigTable::add_routing_header(req, table_name, app_profile_id)
+            .expect("Failed to add routing header");
+
+        // 4. Assert the header was added correctly
+        let metadata = result.metadata();
+        let header_val = metadata
+            .get("x-goog-request-params")
+            .expect("Header missing")
+            .to_str()
+            .expect("Header is not a valid string");
+
+        // "projects/my-project..." should become "projects%2Fmy-project..."
+        let expected_table = "projects%2Fmy-project%2Finstances%2Fmy-instance%2Ftables%2Fmy-table";
+        let expected = format!("table_name={}&app_profile_id=default", expected_table);
+
+        assert_eq!(header_val, expected);
+    }
+
+    #[test]
+    fn test_add_routing_header_empty_app_profile() {
+        // 1. Setup a dummy request
+        let req = Request::new(());
+
+        // 2. Define standard inputs (notice the slashes that need encoding)
+        let table_name = "projects/my-project/instances/my-instance/tables/my-table";
+        let app_profile_id = "";
+
+        // 3. Call the function
+        let result = BigTable::add_routing_header(req, table_name, app_profile_id)
+            .expect("Failed to add routing header");
+
+        // 4. Assert the header was added correctly
+        let metadata = result.metadata();
+        let header_val = metadata
+            .get("x-goog-request-params")
+            .expect("Header missing")
+            .to_str()
+            .expect("Header is not a valid string");
+
+        // "projects/my-project..." should become "projects%2Fmy-project..."
+        let expected_table = "projects%2Fmy-project%2Finstances%2Fmy-instance%2Ftables%2Fmy-table";
+        let expected = format!("table_name={}&app_profile_id=", expected_table);
+
+        assert_eq!(header_val, expected);
+    }
+
+    #[test]
+    fn test_add_routing_header_with_special_chars() {
+        let req = Request::new(());
+
+        // Inputs with spaces and special characters
+        let table_name = "my table@name";
+        let app_profile_id = "profile/v1";
+
+        let result = BigTable::add_routing_header(req, table_name, app_profile_id).unwrap();
+
+        let metadata = result.metadata();
+        let header_val = metadata
+            .get("x-goog-request-params")
+            .unwrap()
+            .to_str()
+            .unwrap();
+
+        // Expect space -> %20, @ -> %40, and / -> %2F
+        let expected = "table_name=my%20table%40name&app_profile_id=profile%2Fv1";
+
+        assert_eq!(header_val, expected);
     }
 }

--- a/bigtable_rs/src/bigtable.rs
+++ b/bigtable_rs/src/bigtable.rs
@@ -118,6 +118,60 @@ use googleapis_tonic_google_bigtable_v2::google::bigtable::v2::{
 
 pub mod read_rows;
 
+pub trait RoutingMetadata {
+    fn get_routing_header(&self) -> String;
+}
+
+impl RoutingMetadata for ReadRowsRequest {
+    fn get_routing_header(&self) -> String {
+        format!(
+            "table_name={}&app_profile_id={}",
+            urlencoding::encode(&self.table_name),
+            urlencoding::encode(&self.app_profile_id)
+        )
+    }
+}
+
+impl RoutingMetadata for MutateRowRequest {
+    fn get_routing_header(&self) -> String {
+        format!(
+            "table_name={}&app_profile_id={}",
+            urlencoding::encode(&self.table_name),
+            urlencoding::encode(&self.app_profile_id)
+        )
+    }
+}
+
+impl RoutingMetadata for MutateRowsRequest {
+    fn get_routing_header(&self) -> String {
+        format!(
+            "table_name={}&app_profile_id={}",
+            urlencoding::encode(&self.table_name),
+            urlencoding::encode(&self.app_profile_id)
+        )
+    }
+}
+
+impl RoutingMetadata for CheckAndMutateRowRequest {
+    fn get_routing_header(&self) -> String {
+        format!(
+            "table_name={}&app_profile_id={}",
+            urlencoding::encode(&self.table_name),
+            urlencoding::encode(&self.app_profile_id)
+        )
+    }
+}
+
+impl RoutingMetadata for SampleRowKeysRequest {
+    fn get_routing_header(&self) -> String {
+        format!(
+            "table_name={}&app_profile_id={}",
+            urlencoding::encode(&self.table_name),
+            urlencoding::encode(&self.app_profile_id)
+        )
+    }
+}
+
 /// An alias for Vec<u8> as row key
 type RowKey = Vec<u8>;
 /// A convenient Result type
@@ -482,16 +536,10 @@ pub struct BigTable {
 
 impl BigTable {
     /// Helper to attach `x-goog-request-params` header for table APIs
-    fn add_routing_header<T>(
+    fn add_routing_header<T: RoutingMetadata>(
         mut tonic_req: tonic::Request<T>,
-        table_name: &str,
-        app_profile_id: &str,
     ) -> Result<tonic::Request<T>> {
-        let header_val = format!(
-            "table_name={}&app_profile_id={}",
-            urlencoding::encode(table_name),
-            urlencoding::encode(app_profile_id)
-        );
+        let header_val = tonic_req.get_ref().get_routing_header();
         tonic_req.metadata_mut().insert(
             "x-goog-request-params",
             MetadataValue::from_str(&header_val).map_err(Error::MetadataError)?,
@@ -504,10 +552,7 @@ impl BigTable {
         &mut self,
         request: CheckAndMutateRowRequest,
     ) -> Result<CheckAndMutateRowResponse> {
-        let table_name = request.table_name.clone();
-        let app_profile_id = request.app_profile_id.clone();
-        let tonic_req =
-            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let tonic_req = Self::add_routing_header(request.into_request())?;
 
         let response = self
             .client
@@ -522,10 +567,7 @@ impl BigTable {
         &mut self,
         request: ReadRowsRequest,
     ) -> Result<Vec<(RowKey, Vec<RowCell>)>> {
-        let table_name = request.table_name.clone();
-        let app_profile_id = request.app_profile_id.clone();
-        let tonic_req =
-            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let tonic_req = Self::add_routing_header(request.into_request())?;
         let response = self.client.read_rows(tonic_req).await?.into_inner();
         decode_read_rows_response(self.timeout.as_ref(), response).await
     }
@@ -542,10 +584,7 @@ impl BigTable {
             row_ranges: vec![row_range],
         });
 
-        let table_name = request.table_name.clone();
-        let app_profile_id = request.app_profile_id.clone();
-        let tonic_req =
-            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let tonic_req = Self::add_routing_header(request.into_request())?;
         let response = self.client.read_rows(tonic_req).await?.into_inner();
         decode_read_rows_response(self.timeout.as_ref(), response).await
     }
@@ -555,10 +594,7 @@ impl BigTable {
         &mut self,
         request: ReadRowsRequest,
     ) -> Result<impl Stream<Item = Result<(RowKey, Vec<RowCell>)>>> {
-        let table_name = request.table_name.clone();
-        let app_profile_id = request.app_profile_id.clone();
-        let tonic_req =
-            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let tonic_req = Self::add_routing_header(request.into_request())?;
 
         let response = self.client.read_rows(tonic_req).await?.into_inner();
         let stream = decode_read_rows_response_stream(response).await;
@@ -577,10 +613,7 @@ impl BigTable {
             row_ranges: vec![row_range],
         });
 
-        let table_name = request.table_name.clone();
-        let app_profile_id = request.app_profile_id.clone();
-        let tonic_req =
-            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let tonic_req = Self::add_routing_header(request.into_request())?;
 
         let response = self.client.read_rows(tonic_req).await?.into_inner();
         let stream = decode_read_rows_response_stream(response).await;
@@ -592,10 +625,7 @@ impl BigTable {
         &mut self,
         request: SampleRowKeysRequest,
     ) -> Result<Streaming<SampleRowKeysResponse>> {
-        let table_name = request.table_name.clone();
-        let app_profile_id = request.app_profile_id.clone();
-        let tonic_req =
-            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let tonic_req = Self::add_routing_header(request.into_request())?;
 
         let response = self.client.sample_row_keys(tonic_req).await?.into_inner();
         Ok(response)
@@ -606,10 +636,7 @@ impl BigTable {
         &mut self,
         request: MutateRowRequest,
     ) -> Result<Response<MutateRowResponse>> {
-        let table_name = request.table_name.clone();
-        let app_profile_id = request.app_profile_id.clone();
-        let tonic_req =
-            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let tonic_req = Self::add_routing_header(request.into_request())?;
 
         let response = self.client.mutate_row(tonic_req).await?;
         Ok(response)
@@ -620,10 +647,7 @@ impl BigTable {
         &mut self,
         request: MutateRowsRequest,
     ) -> Result<Streaming<MutateRowsResponse>> {
-        let table_name = request.table_name.clone();
-        let app_profile_id = request.app_profile_id.clone();
-        let tonic_req =
-            Self::add_routing_header(request.into_request(), &table_name, &app_profile_id)?;
+        let tonic_req = Self::add_routing_header(request.into_request())?;
 
         let response = self.client.mutate_rows(tonic_req).await?.into_inner();
         Ok(response)
@@ -676,18 +700,15 @@ mod tests {
 
     #[test]
     fn test_add_routing_header_standard() {
-        // 1. Setup a dummy request
-        let req = Request::new(());
+        let req = ReadRowsRequest {
+            table_name: "projects/my-project/instances/my-instance/tables/my-table".to_owned(),
+            app_profile_id: "default".to_owned(),
+            ..ReadRowsRequest::default()
+        };
 
-        // 2. Define standard inputs (notice the slashes that need encoding)
-        let table_name = "projects/my-project/instances/my-instance/tables/my-table";
-        let app_profile_id = "default";
+        let tonic_req = Request::new(req);
+        let result = BigTable::add_routing_header(tonic_req).expect("Failed to add routing header");
 
-        // 3. Call the function
-        let result = BigTable::add_routing_header(req, table_name, app_profile_id)
-            .expect("Failed to add routing header");
-
-        // 4. Assert the header was added correctly
         let metadata = result.metadata();
         let header_val = metadata
             .get("x-goog-request-params")
@@ -695,7 +716,6 @@ mod tests {
             .to_str()
             .expect("Header is not a valid string");
 
-        // "projects/my-project..." should become "projects%2Fmy-project..."
         let expected_table = "projects%2Fmy-project%2Finstances%2Fmy-instance%2Ftables%2Fmy-table";
         let expected = format!("table_name={}&app_profile_id=default", expected_table);
 
@@ -704,18 +724,15 @@ mod tests {
 
     #[test]
     fn test_add_routing_header_empty_app_profile() {
-        // 1. Setup a dummy request
-        let req = Request::new(());
+        let req = ReadRowsRequest {
+            table_name: "projects/my-project/instances/my-instance/tables/my-table".to_owned(),
+            app_profile_id: "".to_owned(),
+            ..ReadRowsRequest::default()
+        };
 
-        // 2. Define standard inputs (notice the slashes that need encoding)
-        let table_name = "projects/my-project/instances/my-instance/tables/my-table";
-        let app_profile_id = "";
+        let tonic_req = Request::new(req);
+        let result = BigTable::add_routing_header(tonic_req).expect("Failed to add routing header");
 
-        // 3. Call the function
-        let result = BigTable::add_routing_header(req, table_name, app_profile_id)
-            .expect("Failed to add routing header");
-
-        // 4. Assert the header was added correctly
         let metadata = result.metadata();
         let header_val = metadata
             .get("x-goog-request-params")
@@ -723,7 +740,6 @@ mod tests {
             .to_str()
             .expect("Header is not a valid string");
 
-        // "projects/my-project..." should become "projects%2Fmy-project..."
         let expected_table = "projects%2Fmy-project%2Finstances%2Fmy-instance%2Ftables%2Fmy-table";
         let expected = format!("table_name={}&app_profile_id=", expected_table);
 
@@ -732,13 +748,14 @@ mod tests {
 
     #[test]
     fn test_add_routing_header_with_special_chars() {
-        let req = Request::new(());
+        let req = ReadRowsRequest {
+            table_name: "my table@name".to_owned(),
+            app_profile_id: "profile/v1".to_owned(),
+            ..ReadRowsRequest::default()
+        };
 
-        // Inputs with spaces and special characters
-        let table_name = "my table@name";
-        let app_profile_id = "profile/v1";
-
-        let result = BigTable::add_routing_header(req, table_name, app_profile_id).unwrap();
+        let tonic_req = Request::new(req);
+        let result = BigTable::add_routing_header(tonic_req).unwrap();
 
         let metadata = result.metadata();
         let header_val = metadata
@@ -747,9 +764,41 @@ mod tests {
             .to_str()
             .unwrap();
 
-        // Expect space -> %20, @ -> %40, and / -> %2F
         let expected = "table_name=my%20table%40name&app_profile_id=profile%2Fv1";
 
         assert_eq!(header_val, expected);
+    }
+
+    #[test]
+    fn test_routing_metadata_trait() {
+        let read_rows = ReadRowsRequest {
+            table_name: "table1".to_owned(),
+            app_profile_id: "profile1".to_owned(),
+            ..Default::default()
+        };
+        assert_eq!(
+            read_rows.get_routing_header(),
+            "table_name=table1&app_profile_id=profile1"
+        );
+
+        let mutate_row = MutateRowRequest {
+            table_name: "table2".to_owned(),
+            app_profile_id: "profile2".to_owned(),
+            ..Default::default()
+        };
+        assert_eq!(
+            mutate_row.get_routing_header(),
+            "table_name=table2&app_profile_id=profile2"
+        );
+
+        let sample_row_keys = SampleRowKeysRequest {
+            table_name: "table3".to_owned(),
+            app_profile_id: "profile3".to_owned(),
+            ..Default::default()
+        };
+        assert_eq!(
+            sample_row_keys.get_routing_header(),
+            "table_name=table3&app_profile_id=profile3"
+        );
     }
 }


### PR DESCRIPTION
AIP-4222 integration
We use the metadata routing headers for optimizing the routing. It is related to https://github.com/liufuyang/bigtable_rs/pull/106. Generally, this routing headers can provide hints for optimal routing (routing closest to bigtable resource). for eg: clients are in asia-east1, but bigtable instance is in us-central1, the routing headers can provide that hint and optimize routing,