### PR TITLE
feat!: Allow selecting `gcp_auth` crypto provider, default to `aws-lc-rs`

### DIFF
--- a/bigtable_rs/Cargo.toml
+++ b/bigtable_rs/Cargo.toml
@@ -22,12 +22,15 @@ tonic-prost = "0.14.2"
 tower = { version = "0.5.1", features = ["util"] }
 # end of above part
 futures-util = "0.3.31"
-gcp_auth = "0.12.2"
+gcp_auth = { version = "0.12.7", default-features = false }
 log = "0.4.20"
 thiserror = "2.0.3"
 
 [features]
-default = ["tonic-tls-aws-lc"]
+default = ["gcp-auth-aws-lc-rs", "tonic-tls-aws-lc"]
+# allows choosing the gcp_auth crypto provider
+gcp-auth-aws-lc-rs = ["gcp_auth/aws-lc-rs"]
+gcp-auth-ring = ["gcp_auth/ring"]
 # allows choosing between tonic/tls-*
 tonic-tls-aws-lc = ["tonic/tls-aws-lc"]
 tonic-tls-ring = ["tonic/tls-ring"]


### PR DESCRIPTION
Change `bigtable_rs` to use `aws-lc-rs` as all crypto providers by default.

`gcp_auth` enables the `ring` crypto provider through its default features,
so it gets linked in alongside the `aws-lc-rs` backend tonic already uses
for TLS.

Disable gcp_auth's default features and expose `gcp-auth-aws-lc-rs` and
`gcp-auth-ring` passthrough features so the crypto provider can be
aligned with the chosen tonic TLS provider. Default to `aws-lc-rs` to
match the existing `tonic-tls-aws-lc` default.

Require `gcp_auth >= 0.12.7`: that release made `ring`/`aws-lc-rs` optional.

BREAKING CHANGE: building bigtable_rs with `default-features = false` now
requires explicitly enabling `gcp-auth-aws-lc-rs` or `gcp-auth-ring`.


I erred a bit on the side of caution here and declared it as a breaking feature, since it changes feature selection behavior. But could see a case for calling it not a breaking feature.

Also alternatively we could potentially add a `ring` as well as `aws-lc-rs` feature in a follow up commit/PR/this PR.
So that by default through `aws-lc-rs` we enable `gcp_auth/aws-lc-rs` as well as `tonic/tls-aws-lc` for example.
